### PR TITLE
npc_heroes_custom.txt

### DIFF
--- a/npc_heroes_custom.txt
+++ b/npc_heroes_custom.txt
@@ -1,0 +1,2471 @@
+// Dota Heroes File
+// NOTE: This is not for creating new heroes, this is for taking a currently existing hero as a template and overriding
+// the specified key-value combinations.  Use override_hero <hero_to_override> for this.
+"DOTAHeroes"
+{
+	"npc_dota_hero_brewmaster_new"
+	{
+		"override_hero"				"npc_dota_hero_brewmaster"
+		"Ability1"					"bvo_creep_hero_aggro"					// Ability 1
+		"Ability2"					"bvo_brewmaster_enrage"					// Ability 2
+		"Ability3"					""					// Ability 3
+		"Ability4"					""					// Ability 4
+		"Ability5"					""					// Ability 5
+		"Ability6"					""					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"90"									// Damage range min.
+		"AttackDamageMax"			"100"
+		"StatusHealth"				"1000"
+		"StatusMana"				"0"
+		"MovementSpeed"				"400"
+		"AttackRate"				"1.500000"
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+
+		"AttributeBaseStrength"		"50"									// Base strength
+		"AttributeStrengthGain"		"5"
+		"AttributeBaseAgility"		"50"									// Base agility
+		"AttributeAgilityGain"		"5"
+		"AttributeBaseIntelligence"	"50"									// Base intelligence
+		"AttributeIntelligenceGain"	"5"
+
+		"ArmorPhysical"				"5"
+	}
+	//=================================================================================================================
+	// CUSTOM HEROES
+	//=================================================================================================================
+	"npc_dota_hero_ichigo"
+	{
+		"override_hero"				"npc_dota_hero_juggernaut"
+		"Model"		"models/hero_ichigo/hero_ichigo_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.0"
+		"VoiceFile"		""
+		"HealthBarOffset"		"180"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_ichigo_skill_1"					// Ability 1
+		"Ability2"					"bvo_ichigo_skill_2"					// Ability 2
+		"Ability3"					"bvo_ichigo_skill_3"					// Ability 3
+		"Ability4"					"bvo_ichigo_skill_4_off"				// Ability 4
+		"Ability5"					"bvo_ichigo_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_ichigo_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.500000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"35"									// Base strength
+		"AttributeStrengthGain"		"4"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"3"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_enel"
+	{
+		"override_hero"				"npc_dota_hero_zuus"
+		"Model"		"models/hero_enel2/hero_enel2_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.95"
+		"VoiceFile"		""
+		"HealthBarOffset"		"200"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_enel_skill_1"					// Ability 1
+		"Ability2"					"bvo_enel_skill_2"					// Ability 2
+		"Ability3"					"bvo_enel_skill_3"					// Ability 3
+		"Ability4"					"bvo_enel_skill_4"					// Ability 4
+		"Ability5"					"bvo_enel_skill_5"					// Ability 5
+		"Ability6"					"bvo_enel_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_razor/razor_base_attack.vpcf"
+		"ProjectileSpeed"			"2000"
+		"AttackRange"				"600"
+		"AttackAcquisitionRange"	"800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"68"
+		"StatusHealth"				"400"
+		"StatusMana"				"10"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"20"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.5"
+		"AttributeBaseIntelligence"	"50"									// Base intelligence
+		"AttributeIntelligenceGain"	"3.75"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_ace"
+	{
+		"override_hero"				"npc_dota_hero_ember_spirit"
+		"Model"		"models/hero_ace/hero_ace_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.25"
+		"VoiceFile"		""
+		"HealthBarOffset"		"180"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_ace_skill_1"					// Ability 1
+		"Ability2"					"bvo_ace_skill_2"					// Ability 2
+		"Ability3"					"bvo_ace_skill_3"					// Ability 3
+		"Ability4"					"bvo_ace_skill_4"					// Ability 4
+		"Ability5"					"bvo_ace_skill_5"					// Ability 5
+		"Ability6"					"bvo_ace_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackRange"				"100"
+		"AttackAcquisitionRange"	"600"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"400"
+		"StatusMana"				"40"
+		"MovementSpeed"				"310"
+		"AttackRate"				"1.240000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.0"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"3.5"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_mihawk"
+	{
+		"override_hero"				"npc_dota_hero_antimage"
+		"Model"		"models/hero_mihawk2/hero_mihawk2_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.2"
+		"VoiceFile"		""
+		"HealthBarOffset"		"170"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_mihawk_skill_1"					// Ability 1
+		"Ability2"					"bvo_mihawk_skill_2"					// Ability 2
+		"Ability3"					"bvo_mihawk_skill_3"					// Ability 3
+		"Ability4"					"bvo_mihawk_skill_4"					// Ability 4
+		"Ability5"					"bvo_mihawk_skill_5"					// Ability 5
+		"Ability6"					"bvo_mihawk_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackRange"				"128"
+		"AttackAcquisitionRange"	"600"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"104"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.470000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.75"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-4"
+	}
+
+	"npc_dota_hero_orihime"
+	{
+		"override_hero"				"npc_dota_hero_luna"
+		"Model"		"models/hero_orihime/hero_orihime_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.25"
+		"VoiceFile"		""
+		"SoundSet" "hero_Crystal"
+		"HealthBarOffset"		"140"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_orihime_skill_1"				// Ability 1
+		"Ability2"					"bvo_orihime_skill_2"				// Ability 2
+		"Ability3"					"bvo_orihime_skill_3"				// Ability 3
+		"Ability4"					"bvo_orihime_skill_4"				// Ability 4
+		"Ability5"					"bvo_orihime_skill_5"				// Ability 5
+		"Ability6"					"bvo_orihime_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_skywrath_mage/skywrath_mage_base_attack.vpcf"
+		"ProjectileSpeed"			"900"
+		"AttackRange"				"650"
+		"AttackAcquisitionRange"	"800"
+
+		"AttackDamageMin"			"42"									// Damage range min.
+		"AttackDamageMax"			"48"
+		"StatusHealth"				"400"
+		"StatusMana"				"18"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"23"									// Base strength
+		"AttributeStrengthGain"		"2.0"
+		"AttributeBaseAgility"		"25"									// Base agility
+		"AttributeAgilityGain"		"2.5"
+		"AttributeBaseIntelligence"	"42"									// Base intelligence
+		"AttributeIntelligenceGain"	"4.5"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_ishida"
+	{
+		"override_hero"				"npc_dota_hero_sniper"
+		"Model"		"models/hero_ishida/hero_ishida_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.25"
+		"VoiceFile"		""
+		"HealthBarOffset"		"130"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_ishida_skill_1"				// Ability 1
+		"Ability2"					"bvo_ishida_skill_2"				// Ability 2
+		"Ability3"					"bvo_ishida_skill_3"				// Ability 3
+		"Ability4"					"bvo_ishida_skill_4"				// Ability 4
+		"Ability5"					"bvo_ishida_skill_5"				// Ability 5
+		"Ability6"					"bvo_ishida_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_drow/drow_frost_arrow.vpcf"
+		"ProjectileSpeed"			"1100"
+		"AttackRange"				"800"
+		"AttackAcquisitionRange"	"1000"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"60"
+		"StatusHealth"				"400"
+		"StatusMana"				"30"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.450000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.25"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"4.5"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_yamamoto"
+	{
+		"override_hero"				"npc_dota_hero_doom_bringer"
+		"Model"		"models/hero_yamamoto/hero_yamamoto_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.35"
+		"VoiceFile"		""
+		"HealthBarOffset"		"200"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_yamamoto_skill_1"					// Ability 1
+		"Ability2"					"bvo_yamamoto_skill_2"					// Ability 2
+		"Ability3"					"bvo_yamamoto_skill_3"					// Ability 3
+		"Ability4"					"bvo_yamamoto_skill_4"					// Ability 4
+		"Ability5"					"bvo_yamamoto_skill_5"					// Ability 5
+		"Ability6"					"bvo_yamamoto_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"35"
+		"MovementSpeed"				"310"
+		"AttackRate"				"1.200000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"4"
+		"AttributeBaseAgility"		"25"									// Base agility
+		"AttributeAgilityGain"		"3"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_zaraki"
+	{
+		"override_hero"				"npc_dota_hero_dragon_knight"
+		"Model"		"models/hero_zaraki/hero_zaraki_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.5"
+		"VoiceFile"		""
+		"HealthBarOffset"		"170"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_zaraki_skill_1"					// Ability 1
+		"Ability2"					"bvo_zaraki_skill_2"					// Ability 2
+		"Ability3"					"bvo_zaraki_skill_3"					// Ability 3
+		"Ability4"					"bvo_zaraki_skill_4"					// Ability 4
+		"Ability5"					"bvo_zaraki_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_zaraki_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"57"									// Damage range min.
+		"AttackDamageMax"			"67"
+		"StatusHealth"				"115"
+		"StatusMana"				"105"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.500000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"45"									// Base strength
+		"AttributeStrengthGain"		"4.25"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"15"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-4"
+	}
+
+	"npc_dota_hero_luffy"
+	{
+		"override_hero"				"npc_dota_hero_riki"
+		"Model"		"models/hero_luffy2/hero_luffy2_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.0"
+		"VoiceFile"		""
+		"HealthBarOffset"		"180"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_luffy_skill_1"					// Ability 1
+		"Ability2"					"bvo_luffy_skill_2"					// Ability 2
+		"Ability3"					"bvo_luffy_skill_3"					// Ability 3
+		"Ability4"					"bvo_luffy_skill_4"					// Ability 4
+		"Ability5"					"bvo_luffy_skill_5"					// Ability 5	
+		"Ability6"					"bvo_luffy_skill_4_soru"					// Ability 6
+		"Ability7"					"bvo_luffy_skill_0"
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"300"
+		"StatusMana"				"40"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.200000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.0"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_zoro"
+	{
+		"override_hero"				"npc_dota_hero_sven"
+		"Model"		"models/hero_zoro/hero_zoro_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.4"
+		"VoiceFile"		""
+		"HealthBarOffset"		"150"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_zoro_skill_1"					// Ability 1
+		"Ability2"					"bvo_zoro_skill_2"					// Ability 2
+		"Ability3"					"bvo_zoro_skill_3"					// Ability 3
+		"Ability4"					"bvo_zoro_skill_4"					// Ability 4
+		"Ability5"					"bvo_zoro_skill_5"					// Ability 5	
+		"Ability6"					"bvo_zoro_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"110"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"64"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"315"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.25"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"3.25"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_crocodile"
+	{
+		"override_hero"				"npc_dota_hero_lycan"
+		"Model"		"models/hero_crocodile/hero_crocodile_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.75"
+		"VoiceFile"		""
+		"HealthBarOffset"		"210"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_crocodile_skill_1"					// Ability 1
+		"Ability2"					"bvo_crocodile_skill_2"					// Ability 2
+		"Ability3"					"bvo_crocodile_skill_3"					// Ability 3
+		"Ability4"					"bvo_crocodile_skill_4"					// Ability 4
+		"Ability5"					"bvo_crocodile_skill_5"					// Ability 5	
+		"Ability6"					"bvo_crocodile_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"104"
+		"StatusHealth"				"10"
+		"StatusMana"				"30"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.470000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.25"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"3.0"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_soifon"
+	{
+		"override_hero"				"npc_dota_hero_phantom_assassin"
+		"Model"		"models/hero_soifon/hero_soifon_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.3"
+		"VoiceFile"		""
+		"HealthBarOffset"		"170"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_soifon_skill_1"					// Ability 1
+		"Ability2"					"bvo_soifon_skill_2"					// Ability 2
+		"Ability3"					"bvo_soifon_skill_3"					// Ability 3
+		"Ability4"					"bvo_soifon_skill_4"					// Ability 4
+		"Ability5"					"bvo_soifon_skill_5"					// Ability 5	
+		"Ability6"					"bvo_soifon_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"72"									// Damage range min.
+		"AttackDamageMax"			"82"
+		"StatusHealth"				"550"
+		"StatusMana"				"40"
+		"MovementSpeed"				"340"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.0"
+		"AttributeBaseAgility"		"45"									// Base agility
+		"AttributeAgilityGain"		"4.75"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_byakuya"
+	{
+		"override_hero"				"npc_dota_hero_kunkka"
+		"Model"		"models/hero_byakuya2/hero_byakuya2_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.1"
+		"VoiceFile"		""
+		"HealthBarOffset"		"150"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_byakuya_skill_1"					// Ability 1
+		"Ability2"					"bvo_byakuya_skill_2"					// Ability 2
+		"Ability3"					"bvo_byakuya_skill_3"					// Ability 3
+		"Ability4"					"bvo_byakuya_skill_4"					// Ability 4
+		"Ability5"					"bvo_byakuya_skill_5"					// Ability 5
+		"Ability6"					"bvo_byakuya_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"400"
+		"StatusMana"				"30"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"2.5"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"3.5"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_toshiro"
+	{
+		"override_hero"				"npc_dota_hero_skeleton_king"
+		"Model"		"models/hero_toshiro/hero_toshiro_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.65"
+		"VoiceFile"		""
+		"HealthBarOffset"		"170"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_toshiro_skill_1"					// Ability 1
+		"Ability2"					"bvo_toshiro_skill_2"					// Ability 2
+		"Ability3"					"bvo_toshiro_skill_3"					// Ability 3
+		"Ability4"					"bvo_toshiro_skill_4_off"				// Ability 4
+		"Ability5"					"bvo_toshiro_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_toshiro_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"300"
+		"StatusMana"				"40"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"3.75"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-4"
+	}
+
+	"npc_dota_hero_rukia"
+	{
+		"override_hero"				"npc_dota_hero_naga_siren"
+		"Model"		"models/hero_rukia/hero_rukia_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.4"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_rukia_skill_1"					// Ability 1
+		"Ability2"					"bvo_rukia_skill_2"					// Ability 2
+		"Ability3"					"bvo_rukia_skill_3"					// Ability 3
+		"Ability4"					"bvo_rukia_skill_4"					// Ability 4
+		"Ability5"					"bvo_rukia_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_rukia_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"400"
+		"StatusMana"				"37"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.520000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"27"									// Base strength
+		"AttributeStrengthGain"		"2.5"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.25"
+		"AttributeBaseIntelligence"	"23"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_hollow"
+	{
+		"override_hero"				"npc_dota_hero_slark"
+		"Model"		"models/hero_hollow/hero_hollow_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.0"
+		"VoiceFile"		""
+		"HealthBarOffset"		"180"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_hollow_skill_1"					// Ability 1
+		"Ability2"					"bvo_hollow_skill_2"					// Ability 2
+		"Ability3"					"bvo_hollow_skill_3"					// Ability 3
+		"Ability4"					"bvo_hollow_skill_4"					// Ability 4
+		"Ability5"					"bvo_hollow_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_hollow_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.500000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.5"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"3.5"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_lucci"
+	{
+		"override_hero"				"npc_dota_hero_night_stalker"
+		"Model"						"models/hero_lucci/hero_lucci_base.vmdl"
+		"DisableWearables" 			"1"
+		"ModelScale" 				"1.2"
+		"VoiceFile"					""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_lucci_skill_1"					// Ability 1
+		"Ability2"					"bvo_lucci_skill_2"					// Ability 2
+		"Ability3"					"bvo_lucci_skill_3"					// Ability 3
+		"Ability4"					"bvo_lucci_skill_4"					// Ability 4
+		"Ability5"					"bvo_lucci_skill_5"					// Ability 5
+		"Ability6"					"bvo_lucci_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"212"
+		"StatusMana"				"40"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.200000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"28"									// Base strength
+		"AttributeStrengthGain"		"3.0"
+		"AttributeBaseAgility"		"42"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_moria"
+	{
+		"override_hero"				"npc_dota_hero_bane"
+		"Model"		"models/hero_moria/hero_moria_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.0"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_moria_skill_1"					// Ability 1
+		"Ability2"					"bvo_moria_skill_2"					// Ability 2
+		"Ability3"					"bvo_moria_skill_3"					// Ability 3
+		"Ability4"					"bvo_moria_skill_4"					// Ability 4
+		"Ability5"					"bvo_moria_skill_5"					// Ability 5
+		"Ability6"					"bvo_moria_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_bane/bane_projectile.vpcf"
+		"ProjectileSpeed"			"900"
+		"AttackRange"				"600"
+		"AttackAcquisitionRange"	"750"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"74"
+		"StatusHealth"				"210"
+		"StatusMana"				"23"
+		"MovementSpeed"				"270"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.0"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"3.25"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_sanji"
+	{
+		"override_hero"				"npc_dota_hero_elder_titan"
+		"Model"		"models/hero_sanji/hero_sanji_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.3"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_sanji_skill_1"					// Ability 1
+		"Ability2"					"bvo_sanji_skill_2"					// Ability 2
+		"Ability3"					"bvo_sanji_skill_3"					// Ability 3
+		"Ability4"					"bvo_sanji_skill_4_off"				// Ability 4
+		"Ability5"					"bvo_sanji_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_sanji_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"400"
+		"StatusMana"				"40"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.210000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.5"
+		"AttributeBaseAgility"		"45"									// Base agility
+		"AttributeAgilityGain"		"4.5"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_usopp"
+	{
+		"override_hero"				"npc_dota_hero_techies"
+		"Model"						"models/hero_usopp/hero_usopp_base.vmdl"
+		"DisableWearables" 			"1"
+		"ModelScale" 				"1.0"
+		"VoiceFile"					""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_usopp_skill_1"					// Ability 1
+		"Ability2"					"bvo_usopp_skill_2"					// Ability 2
+		"Ability3"					"bvo_usopp_skill_3"					// Ability 3
+		"Ability4"					"bvo_usopp_skill_4"					// Ability 4
+		"Ability5"					"bvo_usopp_skill_5"					// Ability 5
+		"Ability6"					"bvo_usopp_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_gyrocopter/gyro_base_attack.vpcf"
+		"ProjectileSpeed"			"1200"
+		"AttackRange"				"900"
+		"AttackAcquisitionRange"	"1200"
+
+		"AttackDamageMin"			"42"									// Damage range min.
+		"AttackDamageMax"			"54"
+		"StatusHealth"				"400"
+		"StatusMana"				"35"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.5"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_nami"
+	{
+		"override_hero"				"npc_dota_hero_lina"
+		"Model"		"models/hero_nami/hero_nami_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.8"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_nami_skill_1"					// Ability 1
+		"Ability2"					"bvo_nami_skill_2"					// Ability 2
+		"Ability3"					"bvo_nami_skill_3"					// Ability 3
+		"Ability4"					"bvo_nami_skill_4"					// Ability 4
+		"Ability5"					"bvo_nami_skill_5"					// Ability 5
+		"Ability6"					"bvo_nami_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_stormspirit/stormspirit_base_attack.vpcf"
+		"ProjectileSpeed"			"1400"
+		"AttackRange"				"600"
+		"AttackAcquisitionRange"	"750"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"68"
+		"StatusHealth"				"500"
+		"StatusMana"				"-45"
+		"MovementSpeed"				"310"
+		"AttackRate"				"1.330000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"20"									// Base strength
+		"AttributeStrengthGain"		"2.25"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"3.0"
+		"AttributeBaseIntelligence"	"45"									// Base intelligence
+		"AttributeIntelligenceGain"	"3.75"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_aokiji"
+	{
+		"override_hero"				"npc_dota_hero_phantom_lancer"
+		"Model"		"models/hero_aokiji/hero_aokiji_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.1"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_aokiji_skill_1"					// Ability 1
+		"Ability2"					"bvo_aokiji_skill_2"					// Ability 2
+		"Ability3"					"bvo_aokiji_skill_3"					// Ability 3
+		"Ability4"					"bvo_aokiji_skill_4"					// Ability 4
+		"Ability5"					"bvo_aokiji_skill_5"					// Ability 5
+		"Ability6"					"bvo_aokiji_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"72"									// Damage range min.
+		"AttackDamageMax"			"94"
+		"StatusHealth"				"210"
+		"StatusMana"				"30"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.200000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.5"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.75"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_yoruichi"
+	{
+		"override_hero"				"npc_dota_hero_spectre"
+		"Model"		"models/hero_yoruichi/hero_yoruichi_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.4"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_yoruichi_skill_1"					// Ability 1
+		"Ability2"					"bvo_yoruichi_skill_2"					// Ability 2
+		"Ability3"					"bvo_yoruichi_skill_3"					// Ability 3
+		"Ability4"					"bvo_yoruichi_skill_4"					// Ability 4
+		"Ability5"					"bvo_yoruichi_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_yoruichi_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"475"
+		"StatusMana"				"40"
+		"MovementSpeed"				"340"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"20"									// Base strength
+		"AttributeStrengthGain"		"2.0"
+		"AttributeBaseAgility"		"50"									// Base agility
+		"AttributeAgilityGain"		"5.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_shinobu"
+	{
+		"override_hero"				"npc_dota_hero_queenofpain"
+		"Model"		"models/hero_shinobu/hero_shinobu_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.75"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_shinobu_skill_1"					// Ability 1
+		"Ability2"					"bvo_shinobu_skill_2"					// Ability 2
+		"Ability3"					"bvo_shinobu_skill_3"					// Ability 3
+		"Ability4"					"bvo_shinobu_skill_4"					// Ability 4
+		"Ability5"					"bvo_shinobu_skill_5"					// Ability 5
+		"Ability6"					"bvo_shinobu_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"54"									// Damage range min.
+		"AttackDamageMax"			"68"
+		"StatusHealth"				"400"
+		"StatusMana"				"35"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"45"									// Base agility
+		"AttributeAgilityGain"		"5.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"1.25"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_kuma"
+	{
+		"override_hero"				"npc_dota_hero_keeper_of_the_light"
+		"Model"		"models/hero_kuma/hero_kuma_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.9"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_kuma_skill_1"					// Ability 1
+		"Ability2"					"bvo_kuma_skill_2"					// Ability 2
+		"Ability3"					"bvo_kuma_skill_3"					// Ability 3
+		"Ability4"					"bvo_kuma_skill_4"					// Ability 4
+		"Ability5"					"bvo_kuma_skill_5"					// Ability 5
+		"Ability6"					"bvo_kuma_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"ProjectileModel"			"particles/units/heroes/hero_keeper_of_the_light/keeper_of_the_light_base_attack.vpcf"
+		"ProjectileSpeed"			"1200"
+		"AttackRange"				"500"
+		"AttackAcquisitionRange"	"750"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"104"
+		"StatusHealth"				"210"
+		"StatusMana"				"30"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"3.25"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.5"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"3.25"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_brook"
+	{
+		"override_hero"				"npc_dota_hero_beastmaster"
+		"Model"		"models/hero_brook/hero_brook_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.8"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_brook_skill_1"					// Ability 1
+		"Ability2"					"bvo_brook_skill_2"					// Ability 2
+		"Ability3"					"bvo_brook_skill_3"					// Ability 3
+		"Ability4"					"bvo_brook_skill_4"					// Ability 4
+		"Ability5"					"bvo_brook_skill_5"					// Ability 5
+		"Ability6"					"bvo_brook_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"74"
+		"StatusHealth"				"400"
+		"StatusMana"				"35"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.260000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_robin"
+	{
+		"override_hero"				"npc_dota_hero_mirana"
+		"Model"		"models/hero_robin2/hero_robin2_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.8"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_robin_skill_1"					// Ability 1
+		"Ability2"					"bvo_robin_skill_2"					// Ability 2
+		"Ability3"					"bvo_robin_skill_3"					// Ability 3
+		"Ability4"					"bvo_robin_skill_4"					// Ability 4
+		"Ability5"					"bvo_robin_skill_5"					// Ability 5
+		"Ability6"					"bvo_robin_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"ProjectileModel"			"particles/units/heroes/hero_puck/puck_base_attack.vpcf"
+		"ProjectileSpeed"			"1200"
+		"AttackRange"				"700"
+		"AttackAcquisitionRange"	"900"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"88"
+		"StatusHealth"				"400"
+		"StatusMana"				"35"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"20"									// Base strength
+		"AttributeStrengthGain"		"2.0"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.5"
+		"AttributeBaseIntelligence"	"50"									// Base intelligence
+		"AttributeIntelligenceGain"	"4.5"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_ikkaku"
+	{
+		"override_hero"				"npc_dota_hero_troll_warlord"
+		"Model"		"models/hero_ikkaku/hero_ikkaku_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.6"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_ikkaku_skill_1"					// Ability 1
+		"Ability2"					"bvo_ikkaku_skill_2"					// Ability 2
+		"Ability3"					"bvo_ikkaku_skill_3"					// Ability 3
+		"Ability4"					"bvo_ikkaku_skill_4_off"				// Ability 4
+		"Ability5"					"bvo_ikkaku_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_ikkaku_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+		"AttackAcquisitionRange"	"600"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"52"									// Damage range min.
+		"AttackDamageMax"			"62"
+		"StatusHealth"				"210"
+		"StatusMana"				"35"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.350000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"4.0"
+		"AttributeBaseAgility"		"25"									// Base agility1
+		"AttributeAgilityGain"		"3.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_tousen"
+	{
+		"override_hero"				"npc_dota_hero_terrorblade"
+		"Model"						"models/hero_tousen/hero_tousen_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "0.9"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_tousen_skill_1"					// Ability 1
+		"Ability2"					"bvo_tousen_skill_2"					// Ability 2
+		"Ability3"					"bvo_tousen_skill_3"					// Ability 3
+		"Ability4"					"bvo_tousen_skill_4"					// Ability 4
+		"Ability5"					"bvo_tousen_skill_5"					// Ability 5
+		"Ability6"					"bvo_tousen_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"110"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+		"AttackAcquisitionRange"	"600"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"30"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.200000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.25"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"3.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_renji"
+	{
+		"override_hero"				"npc_dota_hero_bloodseeker"
+		"Model"						"models/hero_renji/hero_renji_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.4"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_renji_skill_1"					// Ability 1
+		"Ability2"					"bvo_renji_skill_2"					// Ability 2
+		"Ability3"					"bvo_renji_skill_3"					// Ability 3
+		"Ability4"					"bvo_renji_skill_4"					// Ability 4
+		"Ability5"					"bvo_renji_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_renji_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"35"									// Base strength
+		"AttributeStrengthGain"		"4.0"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_sado"
+	{
+		"override_hero"				"npc_dota_hero_slardar"
+		"Model"						"models/hero_sado/hero_sado_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.4"
+		"VoiceFile"		""
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_sado_skill_1"					// Ability 1
+		"Ability2"					"bvo_sado_skill_2"					// Ability 2
+		"Ability3"					"bvo_sado_skill_3"					// Ability 3
+		"Ability4"					"bvo_sado_skill_4"					// Ability 4
+		"Ability5"					"bvo_sado_skill_5_off"				// Ability 5
+		"Ability6"					"bvo_sado_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"210"
+		"StatusMana"				"38"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.550000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"35"									// Base strength
+		"AttributeStrengthGain"		"4.0"
+		"AttributeBaseAgility"		"33"									// Base agility
+		"AttributeAgilityGain"		"2.75"
+		"AttributeBaseIntelligence"	"22"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-4"
+	}
+
+	"npc_dota_hero_megumin"
+	{
+		"override_hero"				"npc_dota_hero_windrunner"
+		"Model"						"models/hero_megumin/hero_megumin_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.0"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Lina"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_megumin_skill_1"					// Ability 1
+		"Ability2"					"bvo_megumin_skill_2"					// Ability 2
+		"Ability3"					"bvo_megumin_skill_3"					// Ability 3
+		"Ability4"					"bvo_megumin_skill_4"					// Ability 4
+		"Ability5"					"bvo_megumin_skill_5"					// Ability 5
+		"Ability6"					"bvo_megumin_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"ProjectileModel"			"particles/base_attacks/ranged_tower_bad.vpcf"
+		"ProjectileSpeed"			"1200"
+		"AttackRange"				"700"
+		"AttackAcquisitionRange"	"900"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"88"
+		"StatusHealth"				"400"
+		"StatusMana"				"35"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.5"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.0"
+		"AttributeBaseIntelligence"	"45"									// Base intelligence
+		"AttributeIntelligenceGain"	"4.5"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_squall"
+	{
+		"override_hero"				"npc_dota_hero_axe"
+		"Model"						"models/hero_squall/hero_squall_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" "1.2"
+		"VoiceFile"		""
+		"SoundSet"					"Hero_Axe"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_squall_skill_1"					// Ability 1
+		"Ability2"					"bvo_squall_skill_2"					// Ability 2
+		"Ability3"					"bvo_squall_skill_3"					// Ability 3
+		"Ability4"					"bvo_squall_skill_4"					// Ability 4
+		"Ability5"					"bvo_squall_skill_5"					// Ability 5
+		"Ability6"					"bvo_squall_skill_0"					// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"270"
+		"StatusMana"				"60"
+		"MovementSpeed"				"340"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.5"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"3.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_mayuri"
+	{
+		"override_hero"				"npc_dota_hero_necrolyte"
+		"Model"						"models/hero_mayuri/hero_mayuri_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.1"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_mayuri_skill_1"				// Ability 1
+		"Ability2"					"bvo_mayuri_skill_2"				// Ability 2
+		"Ability3"					"bvo_mayuri_skill_3"				// Ability 3
+		"Ability4"					"bvo_mayuri_skill_4"				// Ability 4
+		"Ability5"					"bvo_mayuri_skill_5"				// Ability 5
+		"Ability6"					"bvo_mayuri_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"110"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"180"
+		"StatusMana"				"60"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.25"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"3.75"
+		"AttributeBaseIntelligence"	"30"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_law"
+	{
+		"override_hero"				"npc_dota_hero_huskar"
+		"Model"						"models/hero_law/hero_law_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.4"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_law_skill_1"				// Ability 1
+		"Ability2"					"bvo_law_skill_2"				// Ability 2
+		"Ability3"					"bvo_law_skill_3"				// Ability 3
+		"Ability4"					"bvo_law_skill_4"				// Ability 4
+		"Ability5"					"bvo_law_skill_5"				// Ability 5
+		"Ability6"					"bvo_law_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"110"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"72"									// Damage range min.
+		"AttackDamageMax"			"82"
+		"StatusHealth"				"210"
+		"StatusMana"				"40"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"25"									// Base strength
+		"AttributeStrengthGain"		"2.25"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.75"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_whitebeard"
+	{
+		"override_hero"				"npc_dota_hero_earthshaker"
+		"Model"						"models/hero_whitebeard/hero_whitebeard_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"0.9"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_whitebeard_skill_1"				// Ability 1
+		"Ability2"					"bvo_whitebeard_skill_2"				// Ability 2
+		"Ability3"					"bvo_whitebeard_skill_3"				// Ability 3
+		"Ability4"					"bvo_whitebeard_skill_4"				// Ability 4
+		"Ability5"					"bvo_whitebeard_skill_5"				// Ability 5
+		"Ability6"					"bvo_whitebeard_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"92"
+		"StatusHealth"				"460"
+		"StatusMana"				"60"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.350000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"4.0"
+		"AttributeBaseAgility"		"25"									// Base agility
+		"AttributeAgilityGain"		"3.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_rory"
+	{
+		"override_hero"				"npc_dota_hero_templar_assassin"
+		"Model"						"models/hero_rory/hero_rory_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.2"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_rory_skill_1"				// Ability 1
+		"Ability2"					"bvo_rory_skill_2"				// Ability 2
+		"Ability3"					"bvo_rory_skill_3"				// Ability 3
+		"Ability4"					"bvo_rory_skill_4"				// Ability 4
+		"Ability5"					"bvo_rory_skill_5"				// Ability 5
+		"Ability6"					"bvo_rory_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"77"									// Damage range min.
+		"AttackDamageMax"			"87"
+		"StatusHealth"				"360"
+		"StatusMana"				"60"
+		"MovementSpeed"				"315"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"35"									// Base strength
+		"AttributeStrengthGain"		"3.5"
+		"AttributeBaseAgility"		"45"									// Base agility
+		"AttributeAgilityGain"		"5.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"1.5"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_ulquiorra"
+	{
+		"override_hero"				"npc_dota_hero_enigma"
+		"Model"						"models/hero_ulquiorra/hero_ulquiorra_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.1"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_ulquiorra_skill_1"				// Ability 1
+		"Ability2"					"bvo_ulquiorra_skill_2"				// Ability 2
+		"Ability3"					"bvo_ulquiorra_skill_3"				// Ability 3
+		"Ability4"					"bvo_ulquiorra_skill_4"				// Ability 4
+		"Ability5"					"bvo_ulquiorra_skill_5"				// Ability 5
+		"Ability6"					"bvo_ulquiorra_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"72"									// Damage range min.
+		"AttackDamageMax"			"82"
+		"StatusHealth"				"360"
+		"StatusMana"				"60"
+		"MovementSpeed"				"295"
+		"AttackRate"				"1.400000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.25"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_aizen"
+	{
+		"override_hero"				"npc_dota_hero_centaur"
+		"Model"						"models/hero_aizen/hero_aizen_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.3"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_aizen_skill_1"				// Ability 1
+		"Ability2"					"bvo_aizen_skill_2"				// Ability 2
+		"Ability3"					"bvo_aizen_skill_3"				// Ability 3
+		"Ability4"					"bvo_aizen_skill_4"				// Ability 4
+		"Ability5"					"bvo_aizen_skill_5"				// Ability 5
+		"Ability6"					"bvo_aizen_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"100"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"62"									// Damage range min.
+		"AttackDamageMax"			"72"
+		"StatusHealth"				"445"
+		"StatusMana"				"60"
+		"MovementSpeed"				"320"
+		"AttackRate"				"1.250000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_AGILITY"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"3.0"
+		"AttributeBaseAgility"		"35"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_harribel"
+	{
+		"override_hero"				"npc_dota_hero_drow_ranger"
+		"Model"						"models/hero_harribel/hero_harribel_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"4.2"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Axe"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		//"Ability1"					"bvo_whitebeard_skill_1"				// Ability 1
+		//"Ability2"					"bvo_whitebeard_skill_2"				// Ability 2
+		//"Ability3"					"bvo_whitebeard_skill_3"				// Ability 3
+		//"Ability4"					"bvo_whitebeard_skill_4"				// Ability 4
+		//"Ability5"					"bvo_whitebeard_skill_5"				// Ability 5
+		//"Ability6"					"bvo_whitebeard_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"82"									// Damage range min.
+		"AttackDamageMax"			"92"
+		"StatusHealth"				"460"
+		"StatusMana"				"60"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.350000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"4.0"
+		"AttributeBaseAgility"		"25"									// Base agility
+		"AttributeAgilityGain"		"3.0"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.0"
+
+		"ArmorPhysical"				"-3"
+	}
+
+	"npc_dota_hero_akainu"
+	{
+		"override_hero"				"npc_dota_hero_ursa"
+		"Model"						"models/hero_akainu/hero_akainu_base.vmdl"
+		"DisableWearables"			"1"
+		"ModelScale" 				"1.0"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Ursa"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_akainu_skill_1"				// Ability 1
+		"Ability2"					"bvo_akainu_skill_2"				// Ability 2
+		"Ability3"					"bvo_akainu_skill_3"				// Ability 3
+		"Ability4"					"bvo_akainu_skill_4"				// Ability 4
+		"Ability5"					"bvo_akainu_skill_5"				// Ability 5
+		"Ability6"					"bvo_akainu_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"120"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"72"									// Damage range min.
+		"AttackDamageMax"			"82"
+		"StatusHealth"				"400"
+		"StatusMana"				"60"
+		"MovementSpeed"				"300"
+		"AttackRate"				"1.300000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"50"									// Base strength
+		"AttributeStrengthGain"		"3.5"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.5"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"1.5"
+
+		"ArmorPhysical"				"-2"
+	}
+
+	"npc_dota_hero_anzu"
+	{
+		"override_hero"				"npc_dota_hero_enchantress"
+		"Model"						"models/hero_anzu/hero_anzu_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.2"
+		"VoiceFile"					"soundevents/voscripts/game_sounds_vo_enchantress.vsndevts"
+		"SoundSet"					"Hero_ElderTitan"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_anzu_skill_1"				// Ability 1
+		"Ability2"					"bvo_anzu_skill_2"				// Ability 2
+		"Ability3"					"bvo_anzu_skill_3"				// Ability 3
+		"Ability4"					"bvo_anzu_skill_5"				// Ability 4
+		"Ability5"					"bvo_anzu_skill_4"				// Ability 5
+		"Ability6"					"bvo_anzu_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"42"									// Damage range min.
+		"AttackDamageMax"			"52"
+		"StatusHealth"				"360"
+		"StatusMana"				"60"
+		"MovementSpeed"				"280"
+		"AttackRate"				"1.450000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"30"									// Base strength
+		"AttributeStrengthGain"		"2.0"
+		"AttributeBaseAgility"		"20"									// Base agility
+		"AttributeAgilityGain"		"2.0"
+		"AttributeBaseIntelligence"	"50"									// Base intelligence
+		"AttributeIntelligenceGain"	"6.0"
+
+		"ArmorPhysical"				"-1"
+
+		"precache"
+		{
+			"soundfile" "soundevents/anzu_sounds.vsndevts"
+		}
+	}
+
+	"npc_dota_hero_rem"
+	{
+		"override_hero"				"npc_dota_hero_vengefulspirit"
+		"Model"						"models/hero_rem/hero_rem_base.vmdl"
+		"DisableWearables" "1"
+		"ModelScale" 				"1.0"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_ElderTitan"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_rem_skill_1"				// Ability 1
+		"Ability2"					"bvo_rem_skill_2"				// Ability 2
+		"Ability3"					"bvo_rem_skill_3"				// Ability 3
+		"Ability4"					"bvo_rem_skill_4"				// Ability 4
+		"Ability5"					"bvo_rem_skill_5"				// Ability 5
+		"Ability6"					"bvo_rem_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"42"									// Damage range min.
+		"AttackDamageMax"			"52"
+		"StatusHealth"				"360"
+		"StatusMana"				"60"
+		"MovementSpeed"				"290"
+		"AttackRate"				"1.450000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"40"									// Base strength
+		"AttributeStrengthGain"		"4.5"
+		"AttributeBaseAgility"		"40"									// Base agility
+		"AttributeAgilityGain"		"4.0"
+		"AttributeBaseIntelligence"	"20"									// Base intelligence
+		"AttributeIntelligenceGain"	"1.5"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_kissshot"
+	{
+		"override_hero"				"npc_dota_hero_phoenix"
+		"Model"						"models/hero_kissshot/hero_kissshot_base.vmdl"
+		"DisableWearables" 			"1"
+		"ModelScale" 				"1.3"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_Antimage"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_kissshot_skill_1"				// Ability 1
+		"Ability2"					"bvo_kissshot_skill_2"				// Ability 2
+		"Ability3"					"bvo_kissshot_skill_3"				// Ability 3
+		"Ability4"					"bvo_kissshot_skill_4"				// Ability 4
+		"Ability5"					"bvo_kissshot_skill_5"				// Ability 5
+		"Ability6"					"bvo_kissshot_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"128"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_MELEE_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"42"									// Damage range min.
+		"AttackDamageMax"			"52"
+		"StatusHealth"				"320"
+		"StatusMana"				"40"
+		"MovementSpeed"				"330"
+		"AttackRate"				"1.450000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_STRENGTH"
+		"AttributeBaseStrength"		"43"									// Base strength
+		"AttributeStrengthGain"		"4.3"
+		"AttributeBaseAgility"		"32"									// Base agility
+		"AttributeAgilityGain"		"3.2"
+		"AttributeBaseIntelligence"	"25"									// Base intelligence
+		"AttributeIntelligenceGain"	"2.5"
+
+		"ArmorPhysical"				"-1"
+	}
+
+	"npc_dota_hero_perona"
+	{
+		"override_hero"				"npc_dota_hero_dark_willow"
+		"Model"						"models/hero_perona/hero_perona_base.vmdl"
+		"DisableWearables"			"1"
+		"ModelScale" 				"1.0"
+		"VoiceFile"					""
+		"SoundSet"					"Hero_DeathProphet"
+		// Abilities
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityLayout"				"6"
+		"Ability1"					"bvo_perona_skill_1"				// Ability 1
+		"Ability2"					"bvo_perona_skill_2"				// Ability 2
+		"Ability3"					"bvo_perona_skill_3"				// Ability 3
+		"Ability4"					"bvo_perona_skill_4"				// Ability 4
+		"Ability5"					"bvo_perona_skill_5"				// Ability 5
+		"Ability6"					"bvo_perona_skill_0"				// Ability 6
+		"Ability7"					""
+		"Ability8"					""
+		"Ability9"					""
+		"Ability10"					"bvo_special_bonus_magic_resist_10"
+		"Ability11"					"bvo_special_bonus_armor_15"
+		"Ability12"					"bvo_special_bonus_health_650"
+		"Ability13"					"bvo_special_bonus_damage_75"
+		"Ability14"					"bvo_special_bonus_evasion_15"
+		"Ability15"					"bvo_special_bonus_attack_speed_80"
+		"Ability16"					"bvo_special_bonus_lifesteal_3"
+		"Ability17"					"bvo_special_bonus_reduced_damage_10"
+		"Ability18"					""
+
+		"AttackRange"				"700"
+		"AttackCapabilities"		"DOTA_UNIT_CAP_RANGED_ATTACK"
+
+		"VisionNighttimeRange"		"1800"
+		"VisionDaytimeRange"		"1800"
+
+		"AttackDamageMin"			"120"									// Damage range min.
+		"AttackDamageMax"			"132"
+		"StatusHealth"				"180"
+		"StatusMana"				"60"
+		"MovementSpeed"				"320"
+		"AttackRate"				"2.600000"
+
+		"AttributePrimary"			"DOTA_ATTRIBUTE_INTELLECT"
+		"AttributeBaseStrength"		"20"									// Base strength
+		"AttributeStrengthGain"		"2.75"
+		"AttributeBaseAgility"		"30"									// Base agility
+		"AttributeAgilityGain"		"2.25"
+		"AttributeBaseIntelligence"	"40"									// Base intelligence
+		"AttributeIntelligenceGain"	"4.0"
+
+		"ArmorPhysical"				"-1"
+	}
+}


### PR DESCRIPTION
Balancings and Fixes:
Community Update:
- Reduced Lifesteal talents from 10% to 3%
- Reduced Magic Resistance Talent from 25% to 10%

Byakuya:
- Fixed Byakuya Petal ability attack intervals. (Nerfed)
- Increased Byakuya Skill 2 Cooldown from 22 to 30
- Reduced Byakuya Skill 2 Cast Range from 600 to 250
- Reduced AGI Gain from 3.75 to 35
- Reduced Base AGI from 40 to 35
- Reduced STR Gain from 2.75 to 2.5

Akainu:
- Reduced STR gain from 4.5 to 3.5
- Reduced AGI gain from 3.5 to 2.5
- Base Max HP reduced from 410 to 400
- Reduced Akainu's Skill 1 Cast Range from 700 to 500
- Reduced Akainu's Skill 1 Cooldown from 0.5 to 1

Moria:
- Fixed Moria's bat swarm ability attack intervals. (Nerfed)