### PR TITLE
npc_abilities_custom

### DIFF
--- a/game/x_arena/scripts/npc/npc_abilities_custom
+++ b/game/x_arena/scripts/npc/npc_abilities_custom
@@ -1,0 +1,32939 @@
+// Dota Heroes File
+"DOTAAbilities"
+{
+	"Version"		"1"
+
+	//Mimic
+	"bvo_mimic_guard"
+	{
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"					"icons/bvo_mimic_guard"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+
+		"Modifiers"
+		{
+			"bvo_mimic_guard_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/mimic.lua"
+						"Function"		"mimic_spawn"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"utility.lua"
+						"Function"		"respawn_self"
+						"time"			"180"
+					}
+				}
+			}
+
+			"bvo_mimic_guard_buff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "-100"
+				}
+			}
+
+			"bvo_mimic_guard_leash_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/mimic.lua"
+						"Function"		"mimic_guard_die"
+					}
+				}
+		
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"	"particles/custom/units/mimic_guard_leash.vpcf"
+						"EffectAttachType"	"start_at_customorigin"
+						"Target"		"TARGET"
+
+						"ControlPointEntities"
+						{
+							"CASTER"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"		"particles/custom/units/mimic_guard_leash.vpcf"
+		}
+	}
+	//Kailin
+	"bvo_kailin_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+
+		"Modifiers"
+		{
+			"bvo_kailin_skill_0_ai_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"kailin_boss_ai_init"
+					}
+				}
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"kailin_boss_ai"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_kailin_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_1"
+		"AOERadius"							"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastRange"				"800"
+		"AbilityCastPoint"				"0.5"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"20.0"
+		"AbilityManaCost"				"0"
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_kailin_skill_1_modifier"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kailin.lua"
+				"Function"		"bvo_kailin_skill_1"
+				"Target"		"POINT"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_PHYSICAL"
+				"Damage"		"500"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kailin_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+		}
+	}
+
+	"bvo_kailin_skill_2_prep"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_2"
+		"AOERadius"							"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.5"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"40.0"
+		"AbilityManaCost"				"0"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kailin.lua"
+				"Function"		"bvo_kailin_skill_2_prep"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"particle"  "particles/units/heroes/hero_elder_titan/elder_titan_echo_stomp_shock.vpcf"
+		}
+	}
+
+	"bvo_kailin_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_2"
+		"AOERadius"							"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"0.0"
+		"AbilityManaCost"				"0"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kailin.lua"
+				"Function"		"bvo_kailin_skill_2"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"bvo_kailin_skill_2_mc"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_kailin_skill_2_stun_modifier"
+						"Target" 		"TARGET"
+					}
+					"ApplyMotionController"
+					{
+					    "Target" 		"TARGET"
+					    "ScriptFile"    "heroes/ability_kailin.lua"
+					    "HorizontalControlFunction" "PointVacuum"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kailin_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_kailin_skill_2_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "-50"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_earth_spirit/espirit_bouldersmash_target.vpcf"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"particle"  "particles/units/heroes/hero_elder_titan/elder_titan_echo_stomp_shock.vpcf"
+			"model"	"models/hero_kailin/hero_kailin_base.vmdl"
+		}
+	}
+
+	"bvo_kailin_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_kailin_skill_3_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"bvo_kailin_skill_3"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_kailin_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_kailin_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_kailin_skill_4_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"bvo_kailin_skill_4_hit"
+					}
+				}
+
+				"ThinkInterval"  "5.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kailin.lua"
+						"Function"		"bvo_kailin_skill_4"
+					}
+				}
+			}
+		}
+	}
+
+	//BOSS
+	"boss_maximillian_bladebane_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"				"icons/boss_maximillian_bladebane_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityCooldown"						"8"
+
+		"Modifiers"
+		{
+			"boss_maximillian_bladebane_skill_1_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/max_blade/1.lua"
+						"Function"		"spell_start"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/max_blade/0.lua"
+						"Function"		"max_blade_dead"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"utility.lua"
+						"Function"		"respawn_self"
+						"time"			"180"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"utility.lua"
+						"Function"		"create_essence"
+						"Amount"		"5"
+					}
+				}
+			}
+		}
+	}
+
+	"boss_maximillian_bladebane_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"	"icons/boss_maximillian_bladebane_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+		"AOERadius"								"400"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"1000"
+		"AbilityCastPoint"				"0.0"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"				"8.0"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"boss/max_blade/2.lua"
+				"Function"		"Leap"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "boss/max_blade/2.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			    "VerticalControlFunction" 	"LeapVertical"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Rubick.Telekinesis.Cast"
+				"Target" 		"TARGET"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "0.3"
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"boss_maximillian_bladebane_skill_2_freeze_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"boss_maximillian_bladebane_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/max_blade/2.lua"
+						"Function"		"spell_ai"
+					}
+				}
+			}
+
+			"boss_maximillian_bladebane_skill_2_freeze_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"					"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"boss_maximillian_bladebane_skill_2_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_rubick.vsndevts"
+		}
+	}
+
+	"boss_maximillian_bladebane_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"				"icons/boss_maximillian_bladebane_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+
+		"AbilityCooldown"						"10"
+
+		"Modifiers"
+		{
+			"boss_maximillian_bladebane_skill_3_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/max_blade/3.lua"
+						"Function"		"on_hit"
+					}
+				}
+			}
+
+			"boss_maximillian_bladebane_skill_3_burn_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/max_blade/3.lua"
+						"Function"		"checkLeash"
+					}
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PURE"
+						"Damage"		"14"
+					}
+				}
+		
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_DeathProphet.SpiritSiphon.Target"
+						"Target" 		"TARGET"
+					}
+					"AttachEffect"
+					{
+						"EffectName"	"particles/custom/units/mimic_guard_leash.vpcf"
+						"EffectAttachType"	"start_at_customorigin"
+						"Target"		"TARGET"
+
+						"ControlPointEntities"
+						{
+							"CASTER"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+						}
+					}
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"		"particles/custom/units/mimic_guard_leash.vpcf"
+			"soundfile" 	"soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+	}
+
+	"boss_forgotten_one_skill_1" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"				"icons/boss_forgotten_one_skill_1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"add_duration"		"45"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"amount"			"8"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"boss_forgotten_one_skill_1_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"States"
+				{
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/forgotten_one/1.lua"
+						"Function"		"boss_forgotten_one_skill_1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"utility.lua"
+						"Function"		"respawn_self"
+						"time"			"240"
+					}
+				}
+			}
+
+			"boss_forgotten_one_skill_1_add_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/forgotten_one/1.lua"
+						"Function"		"boss_forgotten_one_skill_1_kill"
+					}
+				}
+			}
+		}
+	}
+
+	"boss_forgotten_one_add_skill_1"
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"				"icons/boss_forgotten_one_add_skill_1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"4.0"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"boss_forgotten_one_add_skill_1_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/forgotten_one/1.lua"
+						"Function"		"boss_forgotten_one_skill_1_add_stack"
+					}
+				}
+			}
+
+			"boss_forgotten_one_add_skill_1_poison_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsDebuff"	"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "-1"
+				}
+			}
+		}
+	}
+
+	//DUMMY
+	"custom_vision_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_vision_dummy_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				} 
+			}
+		}
+	}
+
+	"custom_icon_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_icon_dummy_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_PROVIDES_VISION"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"custom_gold_coin_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_gold_coin_dummy_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_gold_coin.lua"
+						"Function"		"gold_coin_init"
+					}
+					"DelayedAction"
+					{
+						"Delay"     "0.1"
+						"Action"    
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"gold_coin_dummy"
+								"Target"		"CASTER"
+							}
+						}
+					}
+				}
+			}
+
+			"custom_phased_modifier"
+			{
+				"Passive"   "0" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"gold_coin_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+		
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_gold_coin.lua"
+						"Function"		"gold_coin_use"
+					}
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 12 0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/props_gameplay/gold_coin001.vmdl"
+			"particle"  "particles/items2_fx/hand_of_midas.vpcf"
+		}
+	}
+
+	"custom_rune_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"haste_speed"					"550"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"haste_duration"				"25"
+			}
+
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"doubledamage_duration"			"45"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"doubledamage_damage"			"100"
+			}
+
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"regen_duration"				"30"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"regen_health"					"100"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"regen_mana"					"67"
+			}
+
+			"08"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"illusion_duration"				"75"
+			}
+			"09"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"illusion_outgoing_damage"		"-65"
+			}
+			"10"
+			{
+				"var_type"							"FIELD_INTEGER"
+				"illusion_incoming_damage_melee"	"200"
+			}
+			"11"
+			{
+				"var_type"							"FIELD_INTEGER"
+				"illusion_incoming_damage_ranged"	"300"
+			}
+
+			"12"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"invisibility_duration"			"45"
+			}
+			"13"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"invisibility_fade_time"		"2"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"custom_rune_dummy_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_rune_activator.lua"
+						"Function"		"rune_init"
+					}
+					"DelayedAction"
+					{
+						"Delay"     "0.1"
+						"Action"    
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"rune_dummy"
+								"Target"		"CASTER"
+							}
+						}
+					}
+				}
+			}
+
+			"rune_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+		
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_rune_activator.lua"
+						"Function"		"rune_use"
+					}
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 12 0"
+					}
+				}
+			}
+
+			"custom_rune_haste_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Duration"			"%haste_duration"
+				"TextureName" 		"rune_haste"
+
+				"EffectName"		"particles/generic_gameplay/rune_haste_owner.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE" "%haste_speed"
+				}
+			}
+
+			"custom_rune_doubledamage_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Duration"			"%doubledamage_duration"
+				"TextureName" 		"rune_doubledamage"
+		
+				"EffectName"		"particles/generic_gameplay/rune_doubledamage_owner.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE" "%doubledamage_damage"
+				}
+			}
+
+			"custom_rune_regen_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Duration"			"%regen_duration"
+				"TextureName" 		"rune_regen"
+		
+				"EffectName"		"particles/generic_gameplay/rune_regen_owner.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "%regen_health"
+				    "MODIFIER_PROPERTY_MANA_REGEN_CONSTANT" "%regen_mana" 
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"runes/rune_regen.lua"
+						"Function"		"rune_regen_force_end"
+					}
+				}
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"runes/rune_regen.lua"
+						"Function"		"rune_regen_end"
+					}
+				}
+			}
+
+			"custom_rune_illusion_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+				"Duration"			"0.1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"runes/rune_illusion.lua"
+						"Function"		"rune_illusion"
+					}
+				}
+			}
+
+			"custom_rune_invisibility_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+				"Duration"			"0.1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"runes/rune_invisibility.lua"
+						"Function"		"rune_invisibility"
+					}
+				}
+			}
+
+			"item_rune_invisibility_fade_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"TextureName" 		"rune_invisibility"
+
+				"OnCreated"
+				{
+					"FireEffect"
+					{
+						"EffectName"        "particles/generic_hero_status/status_invisibility_start.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"item_rune_invisibility_modifier"
+						"Target"
+			            {
+			                "Center" "TARGET"
+			                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+			            }
+						"Duration"		"%invisibility_duration"
+					}
+				}
+			}
+
+			"item_rune_invisibility_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target"		"CASTER"
+						"Duration"		"%invisibility_duration"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"item_rune_invisibility_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAbilityExecuted"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"item_rune_invisibility_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/rune_haste_owner.vpcf"
+			"particle"  "particles/generic_gameplay/rune_doubledamage_owner.vpcf"
+			"particle"  "particles/generic_gameplay/rune_regen_owner.vpcf"
+
+			"particle"  "particles/generic_hero_status/status_invisibility_start.vpcf"
+		}
+	}
+
+	"custom_essence_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_essence_dummy_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_essence.lua"
+						"Function"		"essence_init"
+					}
+				}
+			}
+
+			"essence_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_NONE"
+		
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"items/item_essence.lua"
+						"Function"		"essence_use"
+					}
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 8 0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/props_gameplay/tango.vmdl"
+			"particle"  "particles/items2_fx/hand_of_midas.vpcf"
+		}
+	}
+
+	"custom_point_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_vision_dummy_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"custom_unit_particle" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_HIDDEN | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"custom_unit_particle_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"invoker_chaos_meteor_datadriven"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE"
+		"MaxLevel"						"1"
+		"HotKeyOverride"				"D"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
+		"FightRecapLevel"				"1"
+		"AbilityTextureName"			"invoker_chaos_meteor"
+		"AbilityCastAnimation" 			"ACT_DOTA_CAST_CHAOS_METEOR"
+
+		// Stats
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"700"
+		"AbilityCastPoint"				"0"
+		"AbilityCooldown"				"55"
+		"AbilityManaCost"				"200"
+
+		// Stats
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityModifierSupportValue"	"0.0"	// Mainly about damage
+		
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"particle"				"particles/units/heroes/hero_invoker/invoker_chaos_meteor.vpcf"
+			"particle"				"particles/units/heroes/hero_invoker/invoker_chaos_meteor_fly.vpcf"
+			"particle"				"particles/units/heroes/hero_invoker/invoker_chaos_meteor_burn_debuff.vpcf"
+		}
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"land_time"				"1.3"  //The meteor lands on the ground this many seconds after it was cast.
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"area_of_effect"		"275"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"travel_distance"		"1000"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"travel_speed"			"300"
+			}
+			"05"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"damage_interval"		"0.5"  //The main damage and a burn damage modifier is applied by the meteor this often.
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"vision_distance"		"500"
+			}
+			"07"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"end_vision_duration"	"3.0"
+			}
+			"08"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"main_damage"			"0"
+			}
+			"09"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"burn_duration"			"3.0"
+			}
+			"10"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"burn_dps"				"8"
+			}
+			"11"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"burn_dps_inverval"		"1"
+			}
+		}
+		
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"								"item_ability.lua"
+				"Function"									"invoker_chaos_meteor_datadriven_on_spell_start"
+				"Target"									"POINT"
+				"LandTime"									"%land_time"
+				"TravelSpeed"								"%travel_speed"
+				"VisionDistance"							"%vision_distance"
+				"EndVisionDuration"							"%end_vision_duration"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"modifier_invoker_chaos_meteor_datadriven_unit_ability"
+			{
+				"Passive"			"0"
+				"IsHidden" 			"0"
+				"IsBuff"			"0"
+				"IsDebuff"			"0"
+				"IsPurgable"		"0"
+				
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"  	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO"    	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" 	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE"  		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE"       	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"    		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"  		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+			"modifier_invoker_chaos_meteor_datadriven_main_damage"
+			{
+				"Passive"  			"0"
+				"IsHidden" 			"1"
+				"IsBuff"			"0"
+				"IsDebuff"			"0"
+				"IsPurgable"		"0"
+				
+				"ThinkInterval" 	"%damage_interval"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"item_ability.lua"
+						"Function"				"modifier_invoker_chaos_meteor_datadriven_main_damage_on_interval_think"
+						"AreaOfEffect"			"%area_of_effect"
+						"BurnDuration"			"%burn_duration"
+					}
+				}
+				
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"item_ability.lua"
+						"Function"				"modifier_invoker_chaos_meteor_datadriven_main_damage_on_interval_think"
+						"AreaOfEffect"			"%area_of_effect"
+					}
+				}
+			}
+			"modifier_invoker_chaos_meteor_datadriven_burn_damage"
+			{
+				"Duration"			"%burn_duration"
+				"Passive"  			"0"
+				"IsHidden" 			"0"
+				"IsBuff"			"0"
+				"IsDebuff"			"1"
+				"IsPurgable"		"1"
+				
+				"Attributes" 		"MODIFIER_ATTRIBUTE_MULTIPLE"
+				
+				"ThinkInterval" 	"%burn_dps_inverval"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"item_ability.lua"
+						"Function"				"modifier_invoker_chaos_meteor_datadriven_burn_damage_on_interval_think"
+						"BurnDPSInterval"		"%burn_dps_inverval"
+					}
+				}
+			}
+		}
+	}
+
+	//FOUNTAIN
+	"custom_fountain_super" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"			"custom_fountain_super"
+
+		"Modifiers"
+		{ 
+			"custom_fountain_super_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 -90 0"
+					}
+				}
+			}
+
+			"custom_fountain_aura"
+			{
+				"Passive" "1"
+   				"IsHidden" "0"
+
+				"Aura"        "custom_fountain_aura_effect"
+				"Aura_Radius" "900"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_BOTH"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO"
+			}
+
+			"custom_fountain_aura_effect"
+			{
+				"IsPassive"	"0"
+				"IsHidden"	"0"
+				"IsBuff" "1"
+				"Priority"          "MODIFIER_PRIORITY_ULTRA"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVISIBLE"	"MODIFIER_STATE_VALUE_DISABLED"
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_REGEN_PERCENTAGE" "2"
+					"MODIFIER_PROPERTY_MANA_REGEN_CONSTANT" "10"
+				}
+
+				"EffectName"		"particles/econ/wards/portal/ward_portal_core/ward_portal_eye_sentry.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/wards/portal/ward_portal_core/ward_portal_eye_sentry.vpcf"
+		}
+	}
+
+	"bvo_fountain_protector" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"Modifiers"
+		{
+			"bvo_fountain_protector_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+		
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_CANNOT_MISS"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/fountain_protector.lua"
+						"Function"		"fountain_protector"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/fountain_protector.lua"
+						"Function"		"fountain_protector_hit"
+					}
+				}
+			}
+
+			"bvo_fountain_protector_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_NONE"
+			}
+		}
+	}
+
+	//CORE
+	"bvo_kyuubi_boss"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"					"icons/bvo_kyuubi_boss"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_kyuubi_boss_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+			
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/kyuubi/0.lua"
+						"Function"		"kyuubi_healthbar_init"
+					}
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"boss/kyuubi/0.lua"
+						"Function"		"kyuubi_healthbar"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_oz_single_stun"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_oz_single_stun"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"15.0"
+		"AbilityCastRange"						"800"
+
+		"OnSpellStart"
+		{
+			
+		}
+
+		"Modifiers"
+		{
+			"bvo_oz_single_stun_ai_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"ThinkInterval"  	"1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"bvo_oz_single_stun_ai"
+					}
+				}
+			}
+
+			"bvo_oz_single_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "1"
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_oz_single_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_storm_bolt.vpcf"
+		}
+	}
+
+	"bvo_kyuubi_aoe_stun"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_kyuubi_aoe_stun"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"20.0"
+
+		"OnSpellStart"
+		{
+			
+		}
+
+		"Modifiers"
+		{
+			"bvo_kyuubi_aoe_stun_ai_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"ThinkInterval"  	"1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"bvo_kyuubi_aoe_stun_ai"
+					}
+				}
+			}
+
+			"bvo_kyuubi_aoe_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_mana_on_hit" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"					"icons/bvo_mana_on_hit"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"afk_timeout"		"90.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_model_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"  	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO"    	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" 	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE"  		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE"       	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"    		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"  		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 		 		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 -90 0"
+					}
+				}
+			}
+
+			"bvo_start_game_init"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+			
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_mana_on_hit_modifier"
+			{
+				"Passive"   "1"
+				"IsBuff"    "1"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile" "ability_ability.lua"
+						"Function" "ManaOnAttack"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"afk_anti_camp_apply_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"anti_camp_apply"
+					}
+				}
+
+				"OnOrder"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"afk_anti_camp_apply_modifier"
+						"Target" 		"CASTER"
+					}
+					//"RunScript"
+					//{
+					//	"ScriptFile"	"items/item_tome_of_health.lua"
+					//	"Function"		"item_tome_of_health"
+					//}
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"bvo_start_game_init"
+					}
+				}
+			}
+
+			"bvo_extra_invis_modifier"
+			{
+				"Passive"   "0" //Auto apply this modifier when the spell is learned
+				"IsBuff"    "0" //Display as a green modifier
+				"IsHidden"  "1" //Show in the UI
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVISIBLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"extra_invis_check"
+					}
+				}
+			}
+
+			"bvo_bounty_modifier"
+			{
+				"Passive"   "0"
+				"IsDebuff"  "1"
+				"IsHidden"  "0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_bounty_hunter/bounty_hunter_track_shield.vpcf"
+						"EffectAttachType"  "follow_overhead"
+						"Target"            "TARGET"
+					}
+				}
+
+				"ThinkInterval"  "10.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"updateBounty"
+					}
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"bvo_bounty_earn"
+						"modifier"		"bvo_bounty_modifier"
+					}
+				}
+			}
+
+			"afk_anti_camp_modifier"
+			{
+				"Passive"   "0"
+				"IsBuff"  	"1"
+				"IsHidden"  "0"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability"
+						"Function"		"anti_camp_init"
+					}
+				}
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability"
+						"Function"		"anti_camp_check"
+					}
+				}
+			}
+
+			"afk_anti_camp_apply_modifier"
+			{
+				"Passive"   "0"
+				"IsBuff"  	"1"
+				"IsHidden"  "1"
+
+				"ThinkInterval"	"%afk_timeout"
+				"OnIntervalThink"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"afk_anti_camp_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_bot_ai_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ai/basic.lua"
+						"Function"		"start"
+					}
+				}
+
+				"ThinkInterval"  "0.5"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ai/basic.lua"
+						"Function"		"think"
+					}
+				}
+			}
+
+			"bvo_perma_att_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+			}
+
+			"bvo_tome_of_health_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "35"
+				}
+			}
+
+			"bvo_tome_of_health_stack_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "35"
+				}
+			}
+
+			"bvo_induel_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bounty_hunter/bounty_hunter_track_shield.vpcf"
+			"particle"  "particles/items2_fx/hand_of_midas.vpcf"
+			"particle"			"particles/units/heroes/hero_doom_bringer/doom_bringer_doom_ring.vpcf"
+			"particle"			"particles/status_fx/status_effect_doom.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_doombringer.vsndevts"
+		}
+	}
+
+	"bvo_creep_hero_aggro" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+
+		"Modifiers"
+		{ 
+			"bvo_creep_hero_aggro_modifier"
+			{
+				"Passive"   "1"
+				"IsBuff"    "1"
+				"IsHidden"  "1"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"check_local_aggro"
+					}
+				}
+
+				"OnCreated"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 -90 0"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_creep_immune" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"					"icons/bvo_creep_immune"
+
+		"Modifiers"
+		{ 
+			"bvo_creep_immune_modifier"
+			{
+				"Passive"   "1"
+				"IsBuff"    "1"
+				"IsHidden"  "0"
+			}
+		}
+	}
+
+	"bvo_brewmaster_enrage" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+
+		"Modifiers"
+		{ 
+			"bvo_brewmaster_enrage_modifier"
+			{
+				"Passive"   "1"
+				"IsBuff"    "1"
+				"IsHidden"  "1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/brewmaster.lua"
+						"Function"		"enrage_init"
+					}
+				}
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/brewmaster.lua"
+						"Function"		"enrage_roam"
+					}
+				}
+			}
+
+			"bvo_brewmaster_enrage_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsBuff"    "1"
+				"IsHidden"  "1"
+
+				"EffectName"            	"particles/items_fx/black_king_bar_avatar.vpcf"
+				"EffectAttachType"      	"PATTACH_ABSORIGIN"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/brewmaster.lua"
+						"Function"		"enrage_start"
+					}
+				}
+			}
+
+			"bvo_brewmaster_enrage_remove_modifier"
+			{
+				"Passive"   "0"
+				"IsBuff"    "1"
+				"IsHidden"  "1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/brewmaster.lua"
+						"Function"		"remove"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items_fx/black_king_bar_avatar.vpcf"
+		}
+	}
+
+	"bvo_oz_spawner" 
+	{
+		"BaseClass" "ability_datadriven"
+		"MaxLevel" "1"
+		"AbilityBehavior"   "DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+
+		"Modifiers"
+		{ 
+			"bvo_oz_spawner_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+			
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"ability_ability.lua"
+						"Function"		"respawnOZ"
+					}
+				}
+			}
+		}
+	}
+
+	"creep_mana_drain" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"creep_mana_drain"
+
+		"Modifiers"
+		{
+			"creep_mana_drain_aura"
+			{
+				"Passive" "1"
+   				"IsHidden" "1"
+
+				"Aura"        "creep_mana_drain_effect"
+				"Aura_Radius" "900"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_BOTH"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_CANNOT_MISS"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"creep_mana_drain_effect"
+			{
+				"IsDebuff"	"1"
+				"IsHidden"	"0"
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"units/drain.lua"
+						"Function"		"drain"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_fountain_invu" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		"AbilityTextureName"			"creep_mana_drain"
+
+		"Modifiers"
+		{
+			"bvo_fountain_invu_aura"
+			{
+				"Passive" "1"
+   				"IsHidden" "1"
+
+				"Aura"        "bvo_fountain_invu_effect"
+				"Aura_Radius" "900"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_CANNOT_MISS"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_fountain_invu_effect"
+			{
+				"IsBuff"	"1"
+				"IsHidden"	"1"
+
+				//"States"
+				//{
+				//	"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				//}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "-100"
+				}
+			}
+		}
+	}
+
+	//Ichigo
+	"bvo_ichigo_skill_0"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/ichigo/bvo_ichigo_skill_0"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"7.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"cooldown_bankai"		"3.5"
+			}
+		}
+	}
+
+	"bvo_ichigo_skill_1"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/ichigo/bvo_ichigo_skill_1"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 120 140 160 180 200"
+		"AbilityCooldown"						"8.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_bankai"					"300 425 550 675 800 925"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"particle"  "particles/custom/ichigo/ichigo_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"36.0"
+		"AbilityDuration"						"18.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage"					"20 20 30 40 50"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_chance"					"6 12 18 24 30"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage_b"				"10 10 10 10 10"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_chance_b"				"8 16 24 32 40"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"cleave"						"50 50 50 50 50"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"cleave_aoe"					"250"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ichigo_skill_2_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+				"Duration" "18.0"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%bonus_damage"
+				}
+
+				"EffectName"		"particles/units/heroes/hero_magnataur/magnataur_empower.vpcf"
+				"EffectAttachType"	"attach_hitloc"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"item_ability.lua"
+						"Function"		"item_zanbato"
+						"cleave"		"%cleave"
+						"area"			"%cleave_aoe"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+
+			"bvo_ichigo_skill_2_modifier_b"
+			{
+				"Passive" "0"
+				"IsHidden" "1"
+				"IsBuff" "1"
+				"Duration" "18.0"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%bonus_damage_b"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"ModifierName" "bvo_ichigo_skill_2_modifier"
+			}
+			"RunScript"
+			{
+				"ScriptFile" "heroes/ability_ichigo.lua"
+				"Function" "ichigo_skill_2_b"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.Empower.Target"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_magnataur/magnataur_empower.vpcf"
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_great_cleave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"600"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"0 0 20 40 60"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"2 2 3 4 5"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_skills"				"19.9 29.9 39.9 49.9 59.9"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"300"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"130"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.6"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_cd"					"3.5"
+			}
+			"09"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ichigo_skill_3_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "0.900000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "130"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "300"
+				}
+
+				"EffectName"		"particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"FireSound"
+				{
+					"EffectName"	"sounds\weapons\hero\bloodseeker\blood_rite_cast.vsnd"
+					"Target"		"CASTER"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ichigo.lua"
+						"Function"		"ichigo_skill_3_end"
+					}
+				}
+			}
+
+			"bvo_ichigo_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-20" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Terrorblade.Metamorphosis"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"200"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ichigo_skill_3_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.0"
+					}
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"ichigo_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName" "bvo_ichigo_skill_3_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"	"%duration_autocast"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+			"model"	"models/hero_ichigo/hero_ichigo_bankai_base"
+			"particle"  "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_terrorblade.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_4_extra"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"300 350 400 450 500"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile" "heroes/ability_ichigo.lua"
+				"Function" "ichigo_skill_1"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250 275 300 325 350"
+		"AbilityCooldown"						"75.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"1.5 1.5 2.0 2.0 2.5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"3 3 4 4 5"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"gt_damage"				"300 350 400 450 500"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"2"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ichigo_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"Duration"			"%duration"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/dark_smoke_test.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ichigo_skill_4_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"ichigo_skill_4"
+				"jumps"			"%jumps"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/dark_smoke_test.vpcf"
+		}
+	}
+
+	"bvo_ichigo_skill_4_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250 275 300 325 350"
+		"AbilityCooldown"						"75.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"1.5 1.5 2.0 2.0 2.5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"3 3 4 4 5"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"gt_damage"				"300 350 400 450 500"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"2"
+			}
+		}
+	}
+
+	"bvo_ichigo_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"275"
+		"AbilityCooldown"						"150.0 140.0 130.0 120.0 110.0"
+		"AbilityDuration"						"15.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_damage"			"300"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_armor"			"30"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_duration"				"15"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_health"			"500"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_regen"			"75"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_mp_regen"			"50"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_ms"				"232"
+			}
+			"08"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_str_agi"			"50"
+			}
+			"09"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_cleave"					"25"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ichigo_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Duration"			"15.0"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "300"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "30"
+					"MODIFIER_PROPERTY_STATS_STRENGTH_BONUS" "50"
+					"MODIFIER_PROPERTY_STATS_AGILITY_BONUS" "50"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "500"
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "75"
+					"MODIFIER_PROPERTY_MANA_REGEN_CONSTANT" "50"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "232" 
+				}
+
+				"EffectName"		"particles/econ/items/nightstalker/nightstalker_black_nihility/nightstalker_black_nihility_void_swarm.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Bloodseeker.BloodRage"
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+						}
+					}
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+						}
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"CleaveAttack"
+					{
+						"CleavePercent"         "25"
+						"CleaveRadius"          "400"
+					}
+					"AttachEffect"
+					{
+						"EffectName"        "particles/econ/items/nightstalker/nightstalker_black_nihility/nightstalker_black_nihility_void_hit.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+						}
+					}
+				}
+
+				"ThinkInterval" "14.9"
+
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ichigo.lua"
+						"Function"		"ichigo_skill_5_end"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ichigo.lua"
+						"Function"		"ichigo_skill_5_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"ichigo_skill_5"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/nightstalker/nightstalker_black_nihility/nightstalker_black_nihility_void_swarm.vpcf"
+			"particle" "particles/econ/items/nightstalker/nightstalker_black_nihility/nightstalker_black_nihility_void_hit.vpcf"
+			"particle"  "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+			"model"	"models/hero_ichigo/hero_ichigo_hollow_base.vmdl"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bloodseeker.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"275"
+		"AbilityCooldown"						"150.0 140.0 130.0 120.0 110.0"
+		"AbilityDuration"						"15.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_damage"			"300"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_armor"			"30"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_duration"				"15"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_health"			"500"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_regen"			"75"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_mp_regen"			"50"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_ms"				"232"
+			}
+			"08"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_bonus_str_agi"			"50"
+			}
+			"09"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"i5_cleave"					"25"
+			}
+		}
+	}
+
+	//Hollow Form Skills
+	"bvo_ichigo_skill_5_cero"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_5_cero"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"8.0"
+		"AbilityCastRange"						"1200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"1000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"bvo_ichigo_skill_5_cero"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tinker.Laser"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"ichigo_skill_5_cero_damage"
+				"damage"		"%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/storm_spirit/storm_spirit_orchid_hat/stormspirit_orchid_ball_lightning.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_tinker.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_5_getsuga"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_5_getsuga"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"1000"
+		"AbilityCooldown"						"12"
+		"AbilityCastRange"						"1200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"2000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/custom/ichigo/ichigo_shockwave.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "1200"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"ichigo_skill_5_getsuga"
+				"damage"		"%damage"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/ichigo/ichigo_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_ichigo_skill_5_sonido"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/ichigo/bvo_ichigo_skill_5_sonido"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_5_sonido"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75"
+		"AbilityCooldown"						"3.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		}
+	}
+
+	//Enel
+	"bvo_enel_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_enel_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/enel/ability_enel_0.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_enel_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_enel_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+		"AOERadius"								"%radius"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"125 150 175 200 225 250"
+		"AbilityCooldown"						"12.0"
+		"AbilityCastRange"						"700"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"bolt_amount"			"0 1 2 3 4 5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"radius"				"150"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"offset"				"64"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"interval"				"0.3"
+			}
+			"05"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"150"
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"int_multi"				"2"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/enel/ability_enel_1.lua"
+				"Function"		"bvo_enel_skill_1"
+				"Target"		"POINT"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/zeus/arcana_chariot/zeus_arcana_thundergods_wrath_start.vpcf"
+			"particle"  "particles/custom/enel/bvo_enel_skill_1_zeus_arcana_thundergods_wrath_start.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_zuus.vsndevts"
+		}
+	}
+
+	"bvo_enel_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_enel_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"30.0"
+		"AbilityDuration"						"10.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_damage"					"1.0"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_damage_flat"				"20 40 60 80 100"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_enel_skill_2_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+				"Duration" "10.0"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "100"
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%bonus_damage_flat"
+				}
+
+				"EffectName"		"particles/items2_fx/mjollnir_shield.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_enel.lua"
+						"Function"		"enel_skill_2"
+						"Bonus"			"%bonus_damage"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"ModifierName" "bvo_enel_skill_2_modifier"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Zuus.StaticField"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/items2_fx/mjollnir_shield.vpcf"
+		}
+	}
+
+	"bvo_enel_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_enel_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"1200"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"60.0"
+		"AbilityChannelTime"					"2.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage"					"4 5 6 7 8"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 600 800 1000 1200"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_zuus/zuus_thundergods_wrath_start_e.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Zuus.GodsWrath.PreCast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"1200"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_enel.lua"
+						"Function"		"enel_skill_3"
+						"Bonus"			"%bonus_damage"
+					}
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Zuus.GodsWrath.Target"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_zuus/zuus_thundergods_wrath_start_e.vpcf"
+		}
+	}
+
+	"bvo_enel_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_enel_skill_4"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"100.0 95.0 90.0 85.0 80.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"melee_chance"				"8 11 14 17 20"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"cast_chance"				"30 35 40 45 50"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"duration"					"15"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"int_multi"					"2.5"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"radius"					"1000 1200 1400 1600 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Razor.Storm.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_enel_skill_4_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_enel_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/enel/ability_enel_4.lua"
+						"Function"		"bvo_enel_skill_4_apply"
+					}
+				}
+			}
+
+			"bvo_enel_skill_4_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff" 			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"%melee_chance"
+						"PseudoRandom" 		"DOTA_PSEUDO_RANDOM_JUGG_CRIT"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/enel/ability_enel_4.lua"
+								"Function"		"bvo_enel_skill_4_melee"
+							}
+						}
+						"OnFailure" { }
+					}
+				}
+
+				"OnAbilityExecuted"
+				{
+					"Random"
+					{
+						"Chance"			"%cast_chance"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/enel/ability_enel_4.lua"
+								"Function"		"bvo_enel_skill_4_cast"
+							}
+						}
+						"OnFailure" { }
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_razor.vsndevts"
+			"particle"  "particles/econ/items/sven/sven_warcry_ti5/sven_warcry_cast_arc_lightning.vpcf"
+		}
+	}
+
+	"bvo_enel_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_enel_skill_5"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"%radius"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"700"
+		"AbilityCooldown"						"160.0"
+		"AbilityDuration"						"12.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"30.0 32.5 35.0 37.5 40.0"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"12"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"break_distance"	"800"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"2400"
+			}
+		}
+		
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/enel/ability_enel_5.lua"
+				"Function"		"bvo_enel_skill_5"
+				"Target"		"POINT"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_enel_skill_5_hot_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_enel_skill_5_hot_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"EffectName"		"particles/units/heroes/hero_wisp/wisp_relocate_marker.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_REGEN_PERCENTAGE" "1"
+				}
+
+				"ThinkInterval"		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/enel/ability_enel_5.lua"
+						"Function"		"bvo_enel_skill_5_checkDistance"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"heroes/enel/ability_enel_5.lua"
+						"Function"			"bvo_enel_skill_5_endTether"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_wisp/wisp_relocate_marker.vpcf"
+			"particle"  "particles/custom/enel/raigo.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_razor.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_stormspirit.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_disruptor.vsndevts"
+		}
+	}
+
+	//Ace
+	"bvo_ace_skill_0" 
+	{
+		"BaseClass" 					"ability_datadriven"
+
+		"MaxLevel" 						"1"
+		"AbilityBehavior" 				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_NO"
+		"AbilityTextureName"					"icons/bvo_ace_skill_0"
+
+		"Modifiers"
+		{ 
+			"bvo_ace_skill_0_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "0"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"OnAttacked"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ace"
+						"Function"		"bvo_ace_skill_0"
+						"attacker"		"ATTACKER"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_ace_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ace_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_NO"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"160"
+		"AbilityCooldown"						"10.0"
+		"AbilityCastRange"						"900"
+		"AbilityCastRangeBuffer"				"100"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"325 430 535 640 745 850"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "900"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_NONE"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DragonKnight.BreathFire"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_dragon_knight.vsndevts"
+		}
+	}
+
+	"bvo_ace_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_ace_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		"AOERadius"								"350"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"25.0"
+		"AbilityCastRange"						"700"
+		"AbilityCastRangeBuffer"				"100"
+		"AbilityDuration"						"6.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"80 110 140 170 200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"4 4 4 4 4"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ace_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"        "particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+				"EffectAttachType"  "follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Radius" 	"350"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+					
+						"Action"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_ace"
+								"Function"		"bvo_ace_skill_2"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ace_skill_2_modifier"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"6.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_EmberSpirit.FlameGuard.Cast"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ember_spirit.vsndevts"
+		}
+	}
+
+	"bvo_ace_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ace_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"350"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"35.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 250 300 350 400"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"10 15 20 25 30"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_dps"					"150 175 200 225 250"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration"						"1.0 1.5 2.0 2.5 3.0"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"damage_dps_tick"				"75.0 87.5 100 112.5 125"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ace_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-40" 
+				}
+
+				"ThinkInterval"  "0.5"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PURE"
+						"Damage"		"%damage_dps_tick"//"%damage_dps / 2
+					}
+				}
+			}
+
+			"bvo_ace_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ace"
+				"Function"		"bvo_ace_skill_3"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"350"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ace_skill_3_slow_modifier"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+						"Duration"		"%duration"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ace_skill_3_stun_modifier"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+						"Duration"		"0.5"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ace"
+						"Function"		"bvo_ace_skill_3_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_light_strike_array_ray_team.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_ace_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ace_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"1200"
+
+		"AbilityCastPoint"						"0.3"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"360"
+		"AbilityCooldown"						"60.0"
+		"AbilityDuration"						"1.5"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"800 950 1100 1250 1400"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"projectiles"					"1 1 2 2 3"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ace_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"1200"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO"
+					"Flags"		"DOTA_UNIT_TARGET_FLAG_NOT_ILLUSIONS | DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE"
+					"MaxTargets" "%projectiles"
+					"Random" 	"1"
+				}
+			
+				"Action"    
+				{
+					"TrackingProjectile"
+					{
+						"Target" "TARGET"
+						"EffectName"		"particles/custom/ace/ace_spell_storm_bolt.vpcf"
+						"Dodgeable"			"0"
+						"ProvidesVision"	"1"
+						"VisionRadius"		"300"
+						"MoveSpeed"        	"1200"
+						"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Tower.Fire.Attack"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ace_skill_4_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Sven.StormBoltImpact"
+				"Target" 		"TARGET"
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_sven/sven_storm_bolt_projectile_explosion.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ace.lua"
+				"Function"		"bvo_ace_skill_4_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/custom/ace/ace_spell_storm_bolt.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_sven.vsndevts"
+			"particle"  "particles/units/heroes/hero_sven/sven_storm_bolt_projectile_explosion.vpcf"
+		}
+	}
+
+	"bvo_ace_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ace_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"1000"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"160.0 150.0 140.0 130.0 120.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"30 60 90 120 150"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ace_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ace.lua"
+						"Function"		"bvo_ace_skill_5_dummy"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ace"
+						"Function"		"bvo_ace_skill_5_dead"
+					}
+				}
+			}
+
+			"bvo_ace_skill_5_modifier_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_supernova_egg.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ace.lua"
+						"Function"		"bvo_ace_skill_5_grow"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ace_skill_5_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"4.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Phoenix.SuperNova.Begin"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "4.0"
+				"Action"
+				{
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Radius" 	"1000"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_ace"
+								"Function"		"bvo_ace_skill_5"
+							}
+						}
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Phoenix.SuperNova.Explode"
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_egg.vpcf"
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_reborn.vpcf"
+			"particle"  "particles/base_destruction_fx/gensmoke.vpcf"
+			"model"		"models/heroes/phoenix/phoenix_egg.vmdl"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phoenix.vsndevts"
+		}
+	}
+
+	//Mihawk
+	"bvo_mihawk_skill_0"
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_0"
+
+		"Modifiers"
+		{ 
+			"bvo_mihawk_skill_0_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"item_ability.lua"
+						"Function"		"item_zanbato"
+						"cleave"		"50"
+						"area"			"350"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_great_cleave.vpcf"
+		}
+	}
+
+	"bvo_mihawk_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_1"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCooldown"						"19 18 17 16 15 14"
+		"AbilityDuration"						"5.0"
+		"AbilityManaCost"						"200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"max_attacks"				"3"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"attack_speed_bonus_pct"	"1000"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"bonus_damage"				"1.75 2.0 2.25 2.5 2.75 3.0"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"chance"					"10 14 18 22 26 30"
+			}
+		}
+		
+		// Data driven
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"particle"						"particles/items2_fx/satanic_buff.vpcf"
+		}
+		
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_mihawk.lua"
+				"Function"					"bvo_mihawk_skill_1_init"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_mihawk_skill_1_modifier"
+			{
+				"IsBuff"					"1"
+				"Duration"					"5"
+				
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/items2_fx/satanic_buff.vpcf"
+				"EffectAttachType"	"attach_hitloc"
+			
+				"OnAttack"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"heroes/ability_mihawk.lua"
+						"Function"				"bvo_mihawk_skill_1_decrease_stack"
+					}
+					"Random"
+					{
+						"Chance"			"%chance"
+						"OnSuccess"
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"bvo_mihawk_skill_1_maim_modifier"
+								"Target"
+					            {
+					                "Center" "TARGET"
+					                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+					            }
+								"Duration"		"5"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+				
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT"	"%attack_speed_bonus_pct"
+				}
+			}
+
+			"bvo_mihawk_skill_1_maim_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-22" 
+				}
+			}
+		}
+	}
+
+	"bvo_mihawk_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_2"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"400 450 500 550 600"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AbilityCooldown"						"17.5"
+		"AbilityManaCost"						"200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"5"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"range"				"400 450 500 550 600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/mihawk/ability_mihawk_2.lua"
+				"Function"					"bvo_mihawk_skill_2"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_mihawk_skill_2_stun_modifier"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"0.75"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_mihawk_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_mihawk_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"1000"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"33.0"
+		"AbilityManaCost"				"250"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"160 220 280 340 400"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_mihawk.lua"
+				"Function"		"bvo_mihawk_skill_3"
+				"Target"		"POINT"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/mihawk/mihawk_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_mihawk_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_4"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"%distance"
+
+		"AbilityCastPoint"				"0.5"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"				"70.0"
+		"AbilityManaCost"				"350"
+		"AnimationPlaybackRate"			"2"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"600 625 650 675 700"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"distance"			"700 1050 1400 1750 2100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_mihawk.lua"
+				"Function"		"bvo_mihawk_skill_4"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_mihawk.lua"
+				"Function"		"bvo_mihawk_skill_4_damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/mihawk/mihawk_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_mihawk_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityTextureName"					"icons/bvo_mihawk_skill_5"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_IDLE"
+		"AbilityCooldown"				"130.0"
+		"AbilityManaCost"				"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"11 22 33 44 55"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/mihawk/ability_mihawk_5.lua"
+				"Function"					"bvo_mihawk_skill_5"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_mihawk_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_mihawk_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+		}
+	}
+
+	//Orihime
+	"bvo_orihime_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_0"
+
+		"MaxLevel"						"1"
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_luna.vsndevts"
+			"particle"			"particles/units/heroes/hero_luna/luna_base_attack.vpcf"
+		}
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"range"						"500"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"bounces"					"4"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage_reduction_percent"	"25"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_moon_glaive"
+			{
+				"Passive" 	"1"
+				"IsHidden"	"1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_orihime.lua"
+						"Function"		"moon_glaive_start_create_dummy"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_orihime_skill_0_dummy"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Luna.MoonGlaive.Impact"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			}
+			
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_orihime.lua"
+				"Function"		"moon_glaive_bounce"
+			}
+
+		}
+
+		"Modifiers"
+		{
+			"modifier_moon_glaive_dummy_unit"
+			{
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"					"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"					"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"					"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"					"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FLYING"							"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"bvo_orihime_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 120 140 160 180 200"
+		"AbilityCooldown"						"8.0"
+		"AbilityCastRange"						"1600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/custom/orihime/orihime_skill_1.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "1500"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "200"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_VengefulSpirit.WaveOfTerror"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/orihime/orihime_skill_1.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_vengefulspirit.vsndevts"
+		}
+	}
+
+	"bvo_orihime_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"260"
+		"AbilityCooldown"						"26.0 25.0 24.0 23.0 22.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_block"					"30 50 70 90 110"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_orihime_skill_2_modifier"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"4.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_orihime.lua"
+				"Function"		"bvo_orihime_skill_2_init"
+			}
+			"FireSound"
+			{
+				"EffectName"	"DOTA_Item.LinkensSphere.Target"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_orihime_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/custom/orihime/orihime_skill_2_shield.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_orihime.lua"
+						"Function"		"bvo_orihime_skill_2"
+						"damage"		"%attack_damage"
+					}
+				}
+
+				"ThinkInterval"		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/orihime/ability_orihime_2.lua"
+						"Function"		"bvo_orihime_skill_2_track"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/orihime/orihime_skill_2_shield.vpcf"
+		}
+	}
+
+	"bvo_orihime_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"40.0 35.0 30.0 25.0 20.0"
+		"AbilityCastRange"						"800"
+
+		"Modifiers"
+		{
+			"bvo_orihime_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/items_fx/bottle.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_orihime.lua"
+						"Function"		"bvo_orihime_skill_3"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_orihime_skill_3_modifier"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"7.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_orihime.lua"
+				"Function"		"bvo_orihime_skill_3_init"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_KeeperOfTheLight.Recall.Cast"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items_fx/bottle.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_keeper_of_the_light.vsndevts"
+		}
+	}
+
+	"bvo_orihime_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"2400"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"450"
+		"AbilityCooldown"						"62.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"800 1100 1400 1700 2000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"2400"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"		"DOTA_UNIT_TARGET_FLAG_FOW_VISIBLE"
+				}
+			
+				"Action"    
+				{
+					"TrackingProjectile"
+					{
+						"Target"           	"TARGET"
+						"EffectName"		"particles/units/heroes/hero_keeper_of_the_light/keeper_of_the_light_base_attack.vpcf"
+						"Dodgeable"			"0"
+						"ProvidesVision"	"1"
+						"VisionRadius"		"300"
+						"MoveSpeed"        	"1000"
+						"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_KeeperOfTheLight.ManaLeak.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_KeeperOfTheLight.ProjectileImpact"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_keeper_of_the_light/keeper_of_the_light_base_attack.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_keeper_of_the_light.vsndevts"
+		}
+	}
+
+	"bvo_orihime_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_orihime_skill_5"
+		"AOERadius"						"%radius"
+
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_faceless_void.vsndevts"
+		}
+
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.35"
+		"AbilityCooldown"				"190.0"
+		"AbilityManaCost"				"600"
+
+		// Stats
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityModifierSupportBonus"		"50"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"radius"				"600"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"2.7 2.7 4.0 4.0 5.3"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"vision_radius"			"475"
+			}
+			// Extra
+			"04"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"aura_interval"			"0.1"
+			}
+			// If you want the Chronosphere to ignore Faceless Void then keep it at 1 otherwise set it to 0
+			"05"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"ignore_void"			"1"
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"speed"					"1000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_FacelessVoid.Chronosphere"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"RunScript"
+			{
+				"ScriptFile"		"heroes/ability_orihime.lua"
+				"Function"			"bvo_orihime_skill_5_cast"
+				"Target"			"POINT"
+			}
+		}
+	}
+
+	"bvo_orihime_skill_5_dummy_aura" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"Modifiers"
+		{ 
+			"bvo_orihime_skill_5_dummy_aura_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"	"particles/custom/orihime/orihime_skill_5/orihime_yellowchrono.vpcf"
+						"EffectAttachType"	"attach_origin"
+						"Target"		"TARGET"
+
+						"ControlPoints"
+						{
+							"01"	"600 600 0"
+						}
+					}
+				}
+			}
+
+			"bvo_orihime_skill_5_dummy_aura_create_good"
+			{
+				"Passive" "1"
+   				"IsHidden" "0"
+
+				"Aura"        "bvo_orihime_skill_5_dummy_aura_effect_good"
+				"Aura_Radius" "600"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+			}
+
+			"bvo_orihime_skill_5_dummy_aura_create_bad"
+			{
+				"Passive" "1"
+   				"IsHidden" "0"
+
+				"Aura"        "bvo_orihime_skill_5_dummy_aura_effect_bad"
+				"Aura_Radius" "600"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+			}
+
+			"bvo_orihime_skill_5_dummy_aura_effect_good"
+			{
+				"IsBuff" "1"
+				
+				"ThinkInterval"  "1.3"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_orihime.lua"
+						"Function"		"bvo_orihime_skill_5_good"
+					}
+				}
+			}
+
+			"bvo_orihime_skill_5_dummy_aura_effect_bad"
+			{
+				"IsDebuff" "1"
+
+				"ThinkInterval"  "1.3"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_orihime.lua"
+						"Function"		"bvo_orihime_skill_5_bad"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FROZEN"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"			"particles/custom/orihime/orihime_skill_5/orihime_yellowchrono.vpcf"
+		}
+	}
+
+	//Ishida
+	"bvo_ishida_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"35"
+		"AbilityCooldown"						"6.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ishida.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_ishida_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCooldown"				"24 22 20 18 16 14"
+		"AbilityDuration"				"6.0"
+		"AbilityManaCost"				"100.0 125.0 150.0 175.0 200.0 225.0"
+		
+		// Data driven
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"particle"						"particles/status_fx/status_effect_overpower.vpcf"
+			"particle"						"particles/units/heroes/hero_ursa/ursa_overpower_buff.vpcf"
+		}
+		
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_ishida.lua"
+				"Function"					"bvo_ishida_skill_1_init"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_StormSpirit.StaticRemnantPlant"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_ishida_skill_1_modifier"
+			{
+				"IsBuff"					"1"
+				"Duration"					"6"
+				
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/units/heroes/hero_troll_warlord/troll_warlord_battletrance_buff.vpcf"
+				"EffectAttachType"	"follow_origin"
+			
+				"OnAttack"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"heroes/ability_ishida.lua"
+						"Function"				"bvo_ishida_skill_1_decrease_stack"
+					}
+					"RunScript"
+					{
+						"ScriptFile"			"heroes/ability_ishida.lua"
+						"Function"				"bvo_ishida_skill_1"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ishida.lua"
+				"Function"		"bvo_ishida_skill_1_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_troll_warlord/troll_warlord_battletrance_buff.vpcf"
+			"particle"  "particles/econ/items/puck/puck_merry_wanderer/puck_illusory_orb_merry_wanderer.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_stormspirit.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_puck.vsndevts"
+		}
+	}
+
+	"bvo_ishida_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCastPoint"				"0.4"
+		"AbilityCooldown"				"22"
+		"AbilityManaCost"				"250"
+		"AbilityCastRange"				"900"
+		"AOERadius"						"300"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"arrows"			"13 16 19 22 25"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_ishida.lua"
+				"Function"					"bvo_ishida_skill_2"
+				"Target"					"POINT"
+				"arrows"					"%arrows"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/luna/luna_lucent_ti5/luna_eclipse_cast_moonlight_glow03_ti_5.vpcf"
+				"EffectAttachType"  "follow_overhead"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.Focusfire"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ishida_skill_2_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden" 			"0"
+				"IsBuff"			"0"
+				"IsDebuff"			"0"
+				"IsPurgable"		"0"
+				
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"  	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO"    	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" 	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE"  		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE"       	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"    		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"  		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_ishida_skill_2_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Duration"			"0.05"
+			
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/zeus/lightning_weapon_fx/zuus_lightning_bolt_castfx_ground2.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/econ/items/luna/luna_lucent_ti5/luna_eclipse_cast_moonlight_glow03_ti_5.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_windrunner.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_zuus.vsndevts"
+		}
+	}
+
+	"bvo_ishida_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"0.75"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"32.0"
+		"AbilityCastRange"						"3500"
+		"AbilityChannelTime"					"2.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"750 1100 1450 1800 2150"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ishida.lua"
+				"Function"		"bvo_ishida_skill_3"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.PowershotPull"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_windrunner/windrunner_spell_powershot.vpcf"
+				"MoveSpeed" "2500"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "3500"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Gyrocopter.ART_Barrage.Launch"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_windrunner/windrunner_spell_powershot.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_gyrocopter.vsndevts"
+		}
+	}
+
+	"bvo_ishida_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+		"AOERadius"								"750"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"900 1300 1700 2100 2500"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ishida.lua"
+				"Function"		"bvo_ishida_skill_4"
+				"damage"		"%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Disruptor.KineticField.End"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ishida_skill_4_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+		
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"	"particles/units/heroes/hero_disruptor/disruptor_kineticfield.vpcf"
+						"EffectAttachType"	"attach_origin"
+						"Target"		"TARGET"
+
+						"ControlPoints"
+						{
+							"01"	"750 750 0"
+							"02"	"2.5 0 0"
+						}
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"  	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO"    	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" 	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE"  		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE"       	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" 		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"   		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"    		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"  		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_disruptor/disruptor_kineticfield.vpcf"
+			"particle"  "particles/units/heroes/hero_disruptor/disruptor_thunder_strike_bolt.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_disruptor.vsndevts"
+		}
+	}
+
+	"bvo_ishida_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ishida_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"210.0 200.0 190.0 180.0 170.0"
+		"AbilityDuration"						"50.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"175"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"5"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"100"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.2"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_agi"					"60"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_cd"					"3.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ishida_skill_5_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_NONE"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.200000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%bonus_e_ms"
+					"MODIFIER_PROPERTY_STATS_AGILITY_BONUS" "%bonus_e_agi"
+				}
+
+				"EffectName"		"particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ishida_skill_5_aura"
+						"Target" 		"CASTER"
+						"Duration"		"50.0"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ishida.lua"
+						"Function"		"bvo_ishida_skill_5"
+					}
+				}
+			}
+
+			"bvo_ishida_skill_5_aura"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+		
+				"Aura"        "bvo_ishida_skill_5_aura_effect"
+				"Aura_Radius" "700"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO"
+			}
+
+			"bvo_ishida_skill_5_lost_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+			}
+
+			"bvo_ishida_skill_5_aura_effect"
+			{
+				"IsDebuff" "1"
+				
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ishida.lua"
+						"Function"		"bvo_ishida_skill_5_aura"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"ModifierName" "bvo_ishida_skill_5_modifier"
+				"Duration"	"50.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Terrorblade.Metamorphosis"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_terrorblade.vsndevts"
+		}
+	}
+
+	//Yamamoto
+	"bvo_yamamoto_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yamamoto.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_yamamoto_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"100 125 150 175 200 225"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"chance"				"15 17 19 21 23 25"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yamamoto_skill_1_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"%chance"
+						"OnSuccess"
+						{
+							"FireSound"
+							{
+								"EffectName"	"Hero_Phoenix.FireSpirits.Launch"
+								"Target"
+								{
+									"Center"  	"CASTER"
+									"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+								}
+							}
+							"AttachEffect"
+							{
+								"EffectName"        "particles/dire_fx/dire_ancient_base001_destruction_l1.vpcf"
+								"EffectAttachType"  "follow_origin"
+								"Target"
+								{
+									"Center"  	"CASTER"
+									"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+								}
+							}
+							"ActOnTargets"
+							{
+								"Target"
+								{
+									"Center"  	"CASTER"
+									"Radius" 	"350"
+									"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+									"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+								}
+							
+								"Action"    
+								{
+									"Damage"
+									{
+										"Target"		"TARGET"
+										"Type"			"DAMAGE_TYPE_MAGICAL"
+										"Damage"		"%damage"
+									}
+								}
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/dire_fx/dire_ancient_base001_destruction_l1.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phoenix.vsndevts"
+		}
+	}
+
+	"bvo_yamamoto_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		"AOERadius"								"550"
+
+		"AbilityCooldown"						"18.0"
+		"AbilityManaCost"						"250"
+		"AbilityDuration"						"4.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"400 475 550 625 700"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"burn_dps"				"70 90 110 130 150"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yamamoto_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50" 
+				}
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%burn_dps"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yamamoto.lua"
+				"Function"		"yamamoto_skill_2"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"550"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_yamamoto_skill_2_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"4.0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_light_strike_array.vpcf"
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_yamamoto_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"250"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"275"
+		"AbilityCooldown"						"40.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"3 4 5 6 7"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"1.05 1.4 1.75 2.1 2.45"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_yamamoto_skill_3_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yamamoto.lua"
+				"Function"		"yamamoto_skill_3"
+				"Target"		"POINT"
+				"jumps"			"%jumps"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yamamoto_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_reborn.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phoenix.vsndevts"
+		}
+	}
+
+	"bvo_yamamoto_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"1600"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+
+		"AbilityCooldown"						"100.0 95.0 90.0 85.0 80.0"
+		"AbilityManaCost"						"400"
+		"AbilityDuration"						"20.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"300 450 600 750 900"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"burn_dps"				"100 125 150 175 200"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"4"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"duration"				"20"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yamamoto.lua"
+				"Function"		"yamamoto_skill_4_dummy"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_SkeletonKing.Hellfire_Blast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yamamoto_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"0"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yamamoto.lua"
+						"Function"		"yamamoto_skill_4_dead"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yamamoto.lua"
+				"Function"		"yamamoto_skill_4_pro_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"particle"  "particles/units/heroes/hero_doom_bringer/doom_scorched_earth.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_doom.vsndevts"
+		}
+	}
+
+	"bvo_yamamoto_skill_4_small_burn" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_4"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"burn"					"100 125 150 175 200"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"1"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"bvo_yamamoto_skill_4_small_burn_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_yamamoto_skill_4_small_burn_aura"
+			{
+				"Passive" "1"
+   				"IsHidden" "0"
+
+				"Aura"        "bvo_yamamoto_skill_4_small_burn_effect"
+				"Aura_Radius" "1600"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+			}
+
+			"bvo_yamamoto_skill_4_small_burn_effect"
+			{
+				"IsDebuff" "1"
+
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yamamoto.lua"
+						"Function"		"yamamoto_skill_4_burn_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_supernova_radiance.vpcf"
+		}
+	}
+
+	"bvo_yamamoto_skill_4_big_burn" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_4"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"burn"					"300 450 600 750 900"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"3"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"bvo_yamamoto_skill_4_big_burn_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+				
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_yamamoto_skill_4_big_burn_aura"
+			{
+				"Passive" "1"
+   				"IsHidden" "0"
+
+   				"EffectName"		"particles/dire_fx/fire_barracks.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"Aura"        "bvo_yamamoto_skill_4_big_burn_effect"
+				"Aura_Radius" "200"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+			}
+
+			"bvo_yamamoto_skill_4_big_burn_effect"
+			{
+				"IsDebuff" "1"
+
+				"EffectName"		"particles/units/heroes/hero_huskar/huskar_burning_spear_debuff_odl.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yamamoto.lua"
+						"Function"		"yamamoto_skill_4_burn_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_huskar/huskar_burning_spear_debuff_odl.vpcf"
+			"particle"  "particles/dire_fx/fire_barracks.vpcf"
+		}
+	}
+
+	"bvo_yamamoto_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_yamamoto_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"800"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AbilityCooldown"						"120.0"
+		"AbilityManaCost"						"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_bonus"			"11 22 33 44 55"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_yamamoto.lua"
+				"Function"					"yamamoto_skill_5"
+				"multi"						"%str_bonus"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_yamamoto_skill_5_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"1.5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_yamamoto_skill_5_modifier_enemy"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+				"Duration"		"1.5"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+		}
+		
+		"Modifiers"
+		{
+
+			"bvo_yamamoto_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_yamamoto_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-100" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	//Zaraki
+	"bvo_zaraki_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+		
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+
+				"OnHeroKilled"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_0_stack"
+						"modifier"		"bvo_zaraki_skill_0_modifier_bonus"
+					}
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_0_death"
+						"modifier"		"bvo_zaraki_skill_0_modifier_bonus"
+					}
+				}
+			}
+
+			"bvo_zaraki_skill_0_modifier_bonus"
+			{
+				"IsHidden"	"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "10"
+				}
+			}
+		}
+	}
+
+	"bvo_zaraki_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_block"					"35 43 51 59 67 75"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_1_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_1"
+						"damage"		"%attack_damage"
+						"block"			"%damage_block"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_zaraki_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		"AOERadius"								"700"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"						"18.0"
+		"AbilityManaCost"						"200"
+		"AbilityDuration"						"3.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"300 350 400 450 500"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/items2_fx/veil_of_discord_debuff.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50"
+				   	"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "-5"
+				   	"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE" "-50"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"700"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_zaraki_skill_2_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"3.0"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Nevermore.RequiemOfSouls"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/items2_fx/veil_of_discord_debuff.vpcf"
+			"particle"  "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_nevermore.vsndevts"
+		}
+	}
+
+	"bvo_zaraki_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"400"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"800"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"100"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"leap_acceleration"		"7000.0"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"200 225 250 275 300"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"str_bonus"				"1.0 1.35 1.75 2.15 2.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zaraki.lua"
+				"Function"		"Leap"
+			}
+			"ApplyMotionController"
+			{
+			    "Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			    "ScriptFile"    "heroes/ability_zaraki.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			    "VerticalControlFunction" 	"LeapVertical"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Rubick.Telekinesis.Cast"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zaraki_skill_3_load_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"30.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_3_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_3_init"
+					}
+				}
+			}
+
+			"bvo_zaraki_skill_3_load_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_3_charge"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_rubick.vsndevts"
+		}
+	}
+
+	"bvo_zaraki_skill_3_extra"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_3"
+		"AOERadius"							"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+
+		"AbilityCastPoint"				"0.0"
+
+		"AbilityCooldown"				"0.0"
+		"AbilityManaCost"				"0"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"200 225 250 275 300"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"str_bonus"				"4 5 6 7 8"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"radius"				"400"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+				"EffectAttachType" 	"follow_origin"
+				"EffectRadius"		"%radius"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"ControlPoints"
+				{
+					"01"	"%radius 0 %radius"
+				}
+			}
+
+			"FireSound"
+			{
+				"EffectName"		"Hero_Centaur.HoofStomp"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_zaraki_skill_3_extra_stun"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+						"Duration"		"1.25"
+					}
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PHYSICAL"
+						"Damage"		"%damage"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_3_extra_damage"
+						"multi"			"%str_bonus"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_3_extra_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"particle"	"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_zaraki_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"						"60"
+		"AbilityManaCost"						"300"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"70 85 100 115 130"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"duration"				"40 45 50 55 60"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration_autocast"		"40.1 45.1 50.1 55.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zaraki_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				   	"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE" "%damage"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zaraki.lua"
+						"Function"		"bvo_zaraki_skill_4_dead"
+					}
+				}
+			}
+
+			"bvo_zaraki_skill_4_effect_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+			
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/units/heroes/hero_troll_warlord/troll_warlord_battletrance_buff.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zaraki.lua"
+				"Function"		"bvo_zaraki_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zaraki_skill_4_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration_autocast"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zaraki_skill_4_effect_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_TrollWarlord.BattleTrance.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_troll_warlord.vsndevts"
+			"particle"  "particles/units/heroes/hero_troll_warlord/troll_warlord_battletrance_buff.vpcf"
+		}
+	}
+
+	"bvo_zaraki_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.4"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+
+		"AbilityCooldown"				"140.0"
+		"AbilityManaCost"				"400"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_bonus"				"14 17 20 23 26"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"skill_0_bonus"			"10 12 14 16 18"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zaraki.lua"
+				"Function"		"bvo_zaraki_skill_5"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "TARGET"
+				"EffectName"	 "particles/units/heroes/hero_shadow_demon/shadow_demon_shadow_poison_projectile.vpcf"
+				"MoveSpeed"		 "3000"
+				"StartRadius"	 "300"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "300"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "800"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"						
+			    "ProvidesVision" "1"
+			    "VisionRadius" 	 "300"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.Avalanche"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/earthshaker/egteam_set/hero_earthshaker_egset/earthshaker_fissure_egset.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_tiny.vsndevts"
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zaraki.lua"
+				"Function"		"bvo_zaraki_skill_5_damage"
+				"multi1"		"%str_bonus"
+				"multi2"		"%skill_0_bonus"
+			}
+		}
+	}
+
+	"bvo_zaraki_skill_5_off"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_zaraki_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.4"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+
+		"AbilityCooldown"				"140.0"
+		"AbilityManaCost"				"400"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_bonus"				"14 17 20 23 26"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"skill_0_bonus"			"10 12 14 16 18"
+			}
+		}
+	}
+
+	//Luffy
+	"bvo_luffy_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_0"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_luffy_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+		"AOERadius"								"220"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"11.5"
+		"AbilityManaCost"				"60 85 110 135 160 185"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"200 290 380 470 565 650"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage_2nd"			"100 100 100 100 100 100"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"multi_2nd"				"50 50 50 50 50 50"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_1"
+				"Target"		"POINT"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "0.1"
+				"Action"    
+				{
+					"FireEffect"
+					{
+						"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+						"EffectAttachType" 	"world_origin"
+						"EffectRadius"		"220"
+						"TargetPoint" 		"POINT"
+						"ControlPoints"
+						{
+							"01"	"220 0 220"
+						}
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Centaur.HoofStomp"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Riki.Blink_Strike"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"220"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_1_damage"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_1_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Duration"			"0.5"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_luffy_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"150"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"4"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"21 20 19 18 17"
+		"AbilityManaCost"				"165"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"400 525 625 700 900"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_2_damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_2_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.25"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"TARGET"
+			    "ScriptFile"    "heroes/ability_luffy.lua"
+			    "HorizontalControlFunction" "KnockbackTarget"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_PhantomLancer.SpiritLance.Throw"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_PhantomLancer.SpiritLance.Impact"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_lancer.vsndevts"
+		}
+	}
+
+	"bvo_luffy_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityChannelTime"			"6.0"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CHANNEL_ABILITY_1"
+		"AnimationPlaybackRate"			"1"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"200 220 240 260 280"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"200 300 400 500 600"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage_tick"			"50 75 100 125 150"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_3_channel_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"6.0"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_3_channel2_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"6.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_3_channel_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_3_cast"
+					}
+				}
+			}
+
+			"bvo_luffy_skill_3_channel2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"ThinkInterval"  "0.05"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_3_cast2"
+					}
+				}
+			}
+
+			"bvo_luffy_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_3_channel_modifier"
+				"Target" 		"CASTER"
+			}
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_3_channel2_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage_tick"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_3_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_storm_bolt.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lycan.vsndevts"
+			"model" "models/hero_luffy2/luffy_punch_base.vmdl"
+		}
+	}
+
+	"bvo_luffy_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"20"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"80"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"5"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"550"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.10"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_hp_regen"				"8"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"						"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.100000"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "%bonus_hp_regen"
+				}
+
+				"EffectName"		"particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard_warp.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Phoenix.SuperNova.Death"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard_warp.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phoenix.vsndevts"
+		}
+	}
+
+	"bvo_luffy_skill_4_soru"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_4_soru"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"8.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_luffy_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_luffy_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"400"
+		"AbilityCastPoint"				"0.4"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"140.0"
+		"AbilityManaCost"				"400"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"1800 2200 2600 3000 3400"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"level_multi_min"		"14 28 42 56 70"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"level_multi_max"		"20 40 60 80 100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_5_mini_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"3.5"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Sven.StormBolt"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_luffy_skill_5_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_luffy_skill_5_mini_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_DISARMED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_SILENCED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_luffy.lua"
+						"Function"		"bvo_luffy_skill_5_mini"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_luffy.lua"
+				"Function"		"bvo_luffy_skill_5_damage"
+				"min"			"%level_multi_min"
+				"max"			"%level_multi_max"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_luffy_skill_5_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"3.0"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_storm_bolt.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_sven.vsndevts"
+			"model" "models/hero_luffy2/luffy_punch_base.vmdl"
+		}
+	}
+
+	//Zoro
+	"bvo_zoro_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"							"1"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+
+		"AbilityCooldown"				"11.0"
+		"AbilityManaCost"				"100"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_0"
+			}
+		}
+	}
+
+	"bvo_zoro_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"1000"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"4"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"80"
+		"AbilityCooldown"						"10.0 9.0 8.0 7.0 6.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "1200"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_zoro_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"1000"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"4"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"18.0 19.0 20.0 21.0 22.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"100 200 300 400 500"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_2"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_2_damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_zoro_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"1200"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"65.0 60.0 55.0 50.0 45.0"
+		"AbilityCastRange"						"1200"
+		"AbilityChannelTime"					"3.5"
+		
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zoro_skill_3_channel"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_3"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_zoro.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_3"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_zoro.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_3_damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zoro_skill_3_channel"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+				"Duration"			"3.5"
+
+				"ThinkInterval"  "0.65"
+				"OnIntervalThink"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_zoro_skill_3_stacks"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_zoro_skill_3_stacks"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_zoro_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"650"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"75.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"500 700 900 1100 1300"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_zoro.lua"
+				"Function"		"bvo_zoro_skill_4"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"650"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PHYSICAL"
+						"Damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_zoro_skill_4_slow"
+						"Target" 		"TARGET"
+						"Duration"		"7.0"
+					}
+				}
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"400"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_zoro.lua"
+						"Function"		"bvo_zoro_skill_4_damage"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_zoro_skill_4_slow"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50"
+				    "MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "-50"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_PHYSICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_invoker/invoker_tornado.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_zoro_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_zoro_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"130.0"
+		"AbilityManaCost"				"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_bonus"			"11 22 33 44 55"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_zoro.lua"
+				"Function"					"bvo_zero_skill_5"
+				"multi"						"%str_bonus"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zoro_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"1.5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_zoro_skill_5_modifier_enemy"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_zoro_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_zoro_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-100" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	//Crocodile
+	"bvo_crocodile_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+		
+		"Modifiers"
+		{
+			"item_evasion_unique"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes" "MODIFIER_ATTRIBUTE_NONE"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_EVASION_CONSTANT" "30"
+				}
+			}
+		}
+	}
+
+	"bvo_crocodile_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"1000"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"12.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_str"						"1.5 2.0 2.5 3.0 3.5 4.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"			"Ability.SandKing_SandStorm.start"
+				"Target"				"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_crocodile.lua"
+				"Function"		"bvo_crocodile_skill_1"
+				"Target"		"POINT"
+			}
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_sandking/sandking_burrowstrike_eruption_ripple_mid.vpcf"
+				"MoveSpeed" "1000"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "1000"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_PHYSICAL"
+				"Damage" "%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_crocodile.lua"
+				"Function"		"bvo_crocodile_skill_1_damage"
+				"multi"			"%bonus_str"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_sandking/sandking_burrowstrike_eruption_ripple_mid.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_sandking.vsndevts"
+		}
+	}
+
+	"bvo_crocodile_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRange"						"150"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"18.0 16.0 14.0 12.0 10.0"
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_crocodile_skill_2_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.25"
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_sandking/sandking_caustic_finale_explode.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Bloodseeker.Rupture.Cast"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_crocodile_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+		
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_crocodile.lua"
+						"Function"		"bvo_crocodile_skill_2"
+					}
+				}
+			}
+
+			"bvo_crocodile_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_sandking/sandking_caustic_finale_explode.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bloodseeker.vsndevts"
+		}
+	}
+
+	"bvo_crocodile_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AOERadius"								"350"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"450"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"45.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 225 250 275 300"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"2.0 2.25 2.5 2.75 3.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_crocodile.lua"
+				"Function"		"bvo_crocodile_skill_3"
+				"Target"		"POINT"
+				"duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"			"Ability.SandKing_SandStorm.start"
+				"Target"				"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_crocodile_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_crocodile_skill_3_dummy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Radius" 	"350"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"bvo_crocodile_skill_3_stun_modifier"
+								"Target" 		"TARGET"
+								"Duration"		"0.1"
+							}
+							"ApplyMotionController"
+							{
+								"Caster" 		"CASTER"
+							    "Target" 		"TARGET"
+							    "ScriptFile"    "heroes/ability_crocodile.lua"
+							    "HorizontalControlFunction" "LeapHorizonal"
+							}
+						}
+					}
+				}
+			}
+
+			"bvo_crocodile_skill_3_damage_dummy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Radius" 	"350"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_crocodile.lua"
+								"Function"		"bvo_crocodile_skill_3_damage"
+								"damage"		"%damage"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_sandking/sandking_sandstorm.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_sandking.vsndevts"
+		}
+	}
+
+	"bvo_crocodile_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"1000"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"65.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_str"						"6 8 10 12 14"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_vengeful/vengeful_wave_of_terror.vpcf"
+				"MoveSpeed" "1000"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "1000"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_SkywrathMage.ArcaneBolt.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_crocodile.lua"
+				"Function"		"bvo_crocodile_skill_4_damage"
+				"multi"			"%bonus_str"
+			}
+			"ActOnTargets"
+			{
+				"FireSound"
+				{
+					"EffectName"	"Hero_Bloodseeker.Rupture"
+					"Target"		"TARGET"
+				}
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"250"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_crocodile.lua"
+						"Function"		"bvo_crocodile_skill_4_damage_aoe"
+						"multi"			"%bonus_str"
+					}
+					"FireEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_vengeful/vengeful_wave_of_terror.vpcf"
+			"particle"  "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_skywrath_mage.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bloodseeker.vsndevts"
+		}
+	}
+
+	"bvo_crocodile_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_crocodile_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"1150"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"0.4"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"150 140 130 120 110"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"health_damage"		"37"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_crocodile_skill_5_cast"
+				"Target" 		"CASTER"
+				"Duration"		"3.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_crocodile.lua"
+				"Function"		"bvo_crocodile_skill_5"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_CAST_ABILITY_1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_crocodile_skill_5_cast"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_undying/undying_decay.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_undying.vsndevts"
+		}
+	}
+
+	//Soi Fon
+	"bvo_soifon_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_soifon.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+			"particle"  "particles/custom/soifon/soifon_blink_end.vpcf"
+			"particle"  "particles/custom/soifon/soifon_blink_start.vpcf"
+		}
+	}
+
+	"bvo_soifon_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCooldown"				"1.1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"bonus_damage"		"75 100 125 150 175 200"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"crit_multi"		"125 150 175 200 225 250"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"chance"			"10 11 12 13 14 15"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_soifon_skill_1_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"OnAttackStart"
+				{
+					"RemoveModifier"
+			        {
+			            "ModifierName" "bvo_soifon_skill_1_crit_modifier"
+			            "Target" "CASTER"
+			        }
+					"Random"
+					{
+						"Chance"			"%chance"
+						"OnSuccess"
+						{
+			               	"RunScript"
+			               	{
+			               		"ScriptFile"	"heroes/soifon/ability_soifon_1.lua"
+			               		"Function"		"bvo_soifon_skill_1"
+			               	}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			"bvo_soifon_skill_1_crit_modifier"
+			{
+			    "IsHidden"  "1"
+
+			    "Properties"
+			    {
+			        "MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE" "%crit_multi"
+			    }
+
+			    "OnAttackLanded"
+			    {
+			        "RemoveModifier"
+			        {
+			            "ModifierName"  "bvo_soifon_skill_1_crit_modifier"
+			            "Target"    "CASTER"
+			        }
+			    }
+			}
+
+			"bvo_soifon_skill_1_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_soifon_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"20.0 18.0 16.0 14.0 12.0"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"bonus_damage"		"400 540 680 820 960"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_soifon_skill_2_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"4.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_TemplarAssassin.Meld"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_soifon_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "25" 
+				}
+
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target"		"CASTER"
+						"Duration"		"4.0"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_soifon.lua"
+						"Function"		"bvo_soifon_skill_2"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PHYSICAL"
+						"Damage"		"%bonus_damage"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_soifon_skill_2_modifier"
+						"Target" 		"CASTER"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_TemplarAssassin.Meld.Attack"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+				}
+
+				"OnAbilityExecuted"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_soifon_skill_2_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_templar_assassin.vsndevts"
+		}
+	}
+
+	"bvo_soifon_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"275"
+		"AbilityCooldown"						"20.0"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"bonus_agi"			"3 4.5 6 7.5 9"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_soifon.lua"
+				"Function"		"bvo_soifon_skill_3"
+				"multi"			"%bonus_agi"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_PhantomAssassin.Strike.Start"
+				"Target"			"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_PhantomAssassin.Strike.End"
+				"Target"			"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts"
+			"particle"  "particles\units\heroes\hero_nyx_assassin\nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	"bvo_soifon_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"55"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"4"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"350"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"80"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.1"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_soifon_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.150000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%bonus_e_ms"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+				}
+
+				"EffectName"		"particles/items2_fx/mjollnir_shield.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_soifon.lua"
+						"Function"		"bvo_soifon_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_soifon_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.static.start"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items2_fx/mjollnir_shield.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_razor.vsndevts"
+		}
+	}
+
+	"bvo_soifon_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_soifon_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityCastRange"						"150"
+		"AbilityManaCost"						"125"
+		"AbilityCooldown"						"2.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"max_miss"			"90 85 80 75 70"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_soifon.lua"
+				"Function"		"bvo_soifon_skill_5_damage"
+					"miss"			"%max_miss"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_soifon_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Duration"			"15.0"
+
+				"EffectName"		"particles/econ/items/sniper/sniper_charlie/sniper_crosshair_b_charlie.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+			}
+
+			"bvo_soifon_skill_5_modifier_auto"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_soifon.lua"
+						"Function"		"bvo_soifon_skill_5_autodamage"
+						"miss"			"%max_miss"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/sniper/sniper_charlie/sniper_crosshair_b_charlie.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_templar_assassin.vsndevts"
+		}
+	}
+
+	//Byakuya
+	"bvo_byakuya_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_byakuya.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_byakuya_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175"
+		"AbilityCooldown"						"10"
+		"AbilityCastRange"						"950"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 480 560 640 720 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/econ/items/death_prophet/death_prophet_acherontia/death_prophet_acher_swarm.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "950"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DeathProphet.CarrionSwarm"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/death_prophet/death_prophet_acherontia/death_prophet_acher_swarm.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+	}
+
+	"bvo_byakuya_skill_1_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175"
+		"AbilityCooldown"						"10.5 10.0 9.5 9.0 8.5 8.0"
+		"AbilityCastRange"						"950"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 480 560 640 720 800"
+			}
+		}
+	}
+
+	"bvo_byakuya_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"30.0"
+		"AbilityCastRange"						"250"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration"						"2 2.25 2.5 2.75 3.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_byakuya_skill_2_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ShadowShaman.Shackles"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_byakuya_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/units/heroes/hero_keeper_of_the_light/keeper_recall_spiral.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"bvo_byakuya_skill_2_stop"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_keeper_of_the_light/keeper_recall_spiral.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_shadowshaman.vsndevts"
+		}
+	}
+
+	"bvo_byakuya_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_3"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastPoint"				"0.5 0.5 0.5"
+
+		// Time		
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCooldown"				"60.0"
+		"AbilityDuration"				"10 11.5 13.0 14.5 16.0"
+
+		// Cost
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityManaCost"				"300"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"radius"				"700"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"spirits"				"12 14 16 18 22"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"spirit_speed"			"800"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"max_distance"			"2000"
+			}
+			"05"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"give_up_distance"		"1200"
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_damage"			"90 90 150 150 180"
+			}
+			"07"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"max_damage"			"30 60 90 140 160"
+			}
+			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"average_damage"		"90 90 150 150 180"
+			}
+			// Extra
+			"9"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"10 11.5 13.0 14.5 16.0"
+			}
+			"10"	
+			{
+				"var_type"					"FIELD_FLOAT"
+				"delay_between_spirits"		"1.0"
+			}
+			"11"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"min_time_between_attacks"	"1.5"
+			}
+			"12"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"e_bonus_damage"			"20 30 40 50 60"
+			}
+			"13"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"e_bonus_armor"				"8 10 12 14 16"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_butterfly/templar_assassin_meld_hit_sparks_butterfly.vpcf"
+			"particle"  "particles/econ/items/enchantress/enchantress_lodestar/enchantress_lodestar_butterfly.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_byakuya.lua"
+				"Function"		"ExorcismDeath"
+			}
+
+			"RemoveModifier"
+			{
+				"ModifierName"	"modifier_exorcism"
+				"Target" 		"CASTER"
+			}
+
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_exorcism"
+				"Target" 		"CASTER"
+				"Duration"		"%AbilityDuration"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_DeathProphet.Exorcism.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_exorcism"
+			{	
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"ExorcismStart"
+					}
+
+					"FireSound"
+					{
+						"EffectName"	"Hero_DeathProphet.Exorcism"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackStart"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"ExorcismAttack"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"ExorcismEnd"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"ExorcismDeath"
+					}
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%e_bonus_damage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%e_bonus_armor"
+				}
+			}
+
+			"modifier_exorcism_spirit"
+			{	
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"ExorcismPhysics"
+					}
+
+					"AttachEffect"
+					{
+						"EffectName"        "particles/econ/items/enchantress/enchantress_lodestar/enchantress_lodestar_butterfly.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+						"ControlPointEntities"
+						{
+							"TARGET"	"attach_origin"
+							"CASTER"	"attach_origin"
+						}
+					}
+				}
+		
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FLYING"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"bvo_byakuya_skill_4_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"1350"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"75.0"
+		"AbilityDuration"						"35.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"800 1000 1200 1400 1600"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage"					"100 150 200 250 300"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"minus_armor"					"-10 -12 -16 -22 -30"
+			}
+		}
+	}
+
+	"bvo_byakuya_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"1150"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"75.0"
+		"AbilityDuration"						"35.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"800 1000 1200 1400 1600"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage"					"100 150 200 250 300"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"minus_armor"					"-10 -12 -16 -22 -30"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_byakuya"
+				"Function"		"bvo_byakuya_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_byakuya_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"35.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_LegionCommander.Duel.Cast.Arcana"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_byakuya_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%bonus_damage"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "20" 
+				}
+
+				"ThinkInterval"		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"bvo_byakuya_skill_4_checkDistance"
+						
+						"radius"			"1350"
+						"caster_modifier"	"bvo_byakuya_skill_4_modifier"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"bvo_byakuya_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/items/dragon_knight/fire_tribunal_sword/fire_tribunal_sword.vmdl"
+		}
+	}
+
+	"bvo_byakuya_skill_4_dummy" 
+	{
+		"BaseClass" "ability_datadriven"
+
+		"MaxLevel" "1"
+		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_AURA | DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_4"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"800 1000 1200 1400 1600"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_damage"					"100 150 200 250 300"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"minus_armor"					"-10 -12 -16 -22 -30"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"bvo_byakuya_skill_4_dummy_modifier"
+			{
+				"Passive"   "1" //Auto apply this modifier when the spell is learned
+				"IsHidden"  "1" //Show in the UI
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+				} 
+			}
+
+			"bvo_byakuya_skill_4_dummy_aura_bad"
+			{
+				"Passive"  "1"
+   				"IsHidden" "0"
+
+				"Aura"        "bvo_byakuya_skill_4_dummy_aura_effect_bad"
+				"Aura_Radius" "1350"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+			}
+
+			"bvo_byakuya_skill_4_dummy_aura_effect_bad"
+			{
+				"IsHidden" "0"
+				"IsDebuff" "1"
+				"Properties" 
+				{
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-25"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%minus_armor"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/items/dragon_knight/fire_tribunal_sword/fire_tribunal_sword.vmdl"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_legion_commander.vsndevts"
+		}
+	}
+
+	"bvo_byakuya_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_byakuya_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"0.25"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"150.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"level_multi"					"20 40 60 80 100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Omniknight.GuardianAngel.Cast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_byakuya_skill_5_cmd"
+				"Target" 		"CASTER"
+				"Duration"		"1.25"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "1.25"
+				"Action"    
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Omniknight.Purification"
+						"Target" 		"CASTER"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_byakuya.lua"
+						"Function"		"bvo_byakuya_skill_5"
+					}
+					"ApplyMotionController"
+					{
+					    "Target" 		"CASTER"
+					    "ScriptFile"    "heroes/ability_byakuya.lua"
+					    "HorizontalControlFunction" "LeapHorizonal"
+					}
+					"LinearProjectile"
+					{
+						"Target" "POINT"
+						"EffectName" ""
+						"MoveSpeed" "2000"
+						"StartRadius" "250"
+						"EndRadius" "250"
+						"FixedDistance" "1000"
+						"StartPosition" "CASTER"
+						"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+						"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						"HasFrontalCone" "0"
+						"ProvidesVision" "1"
+						"VisionRadius" "250"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_byakuya_skill_5_cmd"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_omniknight/omniknight_guardian_angel_ally.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"EffectRadius"		"200"
+						"Target"            "CASTER"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_byakuya.lua"
+				"Function"		"bvo_byakuya_skill_5_damage"
+				"multi"			"%level_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_omniknight/omniknight_guardian_angel_ally.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_omniknight.vsndevts"
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_sanity_eclipse_area.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_obsidian_destroyer.vsndevts"
+		}
+	}
+
+	//Toshiro
+	"bvo_toshiro_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"7.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_toshiro.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 115 130 145 160 175"
+		"AbilityCooldown"						"10.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"300 375 450 525 600 675"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_1_slow"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-25" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_tusk/tusk_ice_shards_projectile.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "250"
+				"EndRadius" "250"
+				"FixedDistance" "1000"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tusk.IceShards.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tusk.IceShards"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_toshiro.lua"
+				"Function"		"bvo_toshiro_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_tusk/tusk_ice_shards_projectile.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_tusk.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"400"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"35.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_min"					"200 350 500 650 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_max"					"400 700 1000 1300 1600"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_2_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-20" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"400"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_toshiro.lua"
+						"Function"		"bvo_toshiro_skill_2_damage"
+						"damage_min"	"%damage_min"
+						"damage_max"	"%damage_max"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_2_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"4.0"
+					}
+				}
+			}
+			"FireEffect"
+			{
+				"TargetPoint"			"POINT"
+				"EffectName"			"particles/units/heroes/hero_crystalmaiden/maiden_crystal_nova.vpcf"
+				"EffectAttachType"		"world_origin"
+				"ControlPoints"
+				{
+					"01"				"400 2 800"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"			"Hero_Crystal.CrystalNova"
+				"Target"				"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/crystal_maiden/crystal_maiden_cowl_of_ice/maiden_crystal_nova_cowlofice.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_crystalmaiden.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_2_bankai"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_2_bankai"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"400"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"35.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_min"					"200 350 500 650 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_max"					"400 700 1000 1300 1600"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_2_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-20" 
+				}
+			}
+
+			"bvo_toshiro_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_toshiro.lua"
+						"Function"		"bvo_toshiro_skill_2_damage"
+						"damage_min"	"%damage_min"
+						"damage_max"	"%damage_max"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_2_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"4.0"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tusk.FrozenSigil.Cast"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_toshiro.lua"
+				"Function"		"bvo_toshiro_skill_2_bankai"
+				"Target"		"POINT"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"400"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_2_stun_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"1.5"
+					}
+					"ApplyMotionController"
+					{
+					    "Target" 		"TARGET"
+					    "ScriptFile"    "heroes/ability_toshiro.lua"
+					    "HorizontalControlFunction" "LeapHorizonal"
+					}
+				}
+			}
+			"DelayedAction"
+			{
+				"Delay"     "1.5"
+				"Action"    
+				{
+					"FireEffect"
+					{
+						"TargetPoint"			"POINT"
+						"EffectName"			"particles/units/heroes/hero_crystalmaiden/maiden_crystal_nova.vpcf"
+						"EffectAttachType"		"world_origin"
+						"ControlPoints"
+						{
+							"01"				"400 2 800"
+						}
+					}
+					"FireSound"
+					{
+						"EffectName"			"Hero_Crystal.CrystalNova"
+						"Target"				"CASTER"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/crystal_maiden/crystal_maiden_cowl_of_ice/maiden_crystal_nova_cowlofice.vpcf"
+			"model" "models/heroes/crystal_maiden/crystal_maiden_ice.vmdl"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_crystalmaiden.vsndevts"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_tusk.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"600"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"60 70 90 120 160"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"6 8 12 18 26"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"400 500 600 700 800"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_regen"					"10 20 30 40 50"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"aura_slow"						"-20 -25 -30 -35 -40"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"aura_slow_as"					"-20 -25 -30 -35 -40"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_3_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "%bonus_e_regen"
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/econ/items/ancient_apparition/aa_blast_ti_5/ancient_apparition_ice_blast_sphere_final_explosion_smoke_ti5.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "CASTER"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_3_aura_modifier"
+						"Target" 		"CASTER"
+						"Duration"		"%duration"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_toshiro.lua"
+						"Function"		"bvo_toshiro_skill_3_end"
+					}
+				}
+			}
+
+			"bvo_toshiro_skill_3_aura_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+			
+				"Aura"        "bvo_toshiro_skill_3_slow_aura_effect"
+				"Aura_Radius" "700"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+			}
+
+			"bvo_toshiro_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%aura_slow"
+				    "MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%aura_slow_as"
+				}
+			}
+
+			"bvo_toshiro_skill_3_slow_aura_effect"
+			{
+				"IsDebuff" "1"
+				"IsHidden"	"0"
+
+				"EffectName"		"particles/units/heroes/hero_visage/visage_grave_chill_caster.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties" 
+				{
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%aura_slow"
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%aura_slow_as"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"200"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_3_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.0"
+					}
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_toshiro.lua"
+				"Function"		"bvo_toshiro_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_toshiro_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Winter_Wyvern.WintersCurse.Target"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_visage/visage_grave_chill_caster.vpcf"
+			"particle" "particles/econ/items/ancient_apparition/aa_blast_ti_5/ancient_apparition_ice_blast_sphere_final_explosion_smoke_ti5.vpcf"
+			"model" "models/hero_toshiro/toshiro_wings_base.vmdl"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_winter_wyvern.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"0.25"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"70.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"agi_multi"						"8 9 10 11 12"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_toshiro_skill_4_cmd"
+				"Target" 		"CASTER"
+				"Duration"		"0.75"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "0.75"
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_toshiro.lua"
+						"Function"		"bvo_toshiro_skill_4"
+					}
+					"ApplyMotionController"
+					{
+					    "Target" 		"CASTER"
+					    "ScriptFile"    "heroes/ability_toshiro.lua"
+					    "HorizontalControlFunction" "LeapHorizonal4"
+					}
+					"LinearProjectile"
+					{
+						"Target" "POINT"
+						"EffectName" "particles/units/heroes/hero_tusk/tusk_ice_shards_projectile.vpcf"
+						"MoveSpeed" "2000"
+						"StartRadius" "250"
+						"EndRadius" "250"
+						"FixedDistance" "1000"
+						"StartPosition" "CASTER"
+						"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+						"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						"HasFrontalCone" "0"
+						"ProvidesVision" "1"
+						"VisionRadius" "250"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Tusk.IceShards.Cast"
+						"Target" 		"CASTER"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Tusk.IceShards"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_4_cmd"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_toshiro.lua"
+				"Function"		"bvo_toshiro_skill_4_damage"
+				"multi"			"%agi_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_tusk/tusk_ice_shards_projectile.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_tusk.vsndevts"
+		}
+	}
+
+	"bvo_toshiro_skill_4_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"0.25"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"70.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"agi_multi"						"8 9 10 11 12"
+			}
+		}
+	}
+
+	"bvo_toshiro_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"500"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"0.5"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"150.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"hero_multi"					"30 60 90 120 150"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_toshiro_skill_5_cmd"
+				"Target" 		"CASTER"
+				"Duration"		"1.5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_toshiro_skill_5_cmd_enemy"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_toshiro_skill_5_cmd"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-100" 
+				}
+			}
+
+			"bvo_toshiro_skill_5_cmd_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FROZEN"					"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-100" 
+				}
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Winter_Wyvern.ColdEmbrace"
+						"Target" 		"TARGET"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_toshiro.lua"
+						"Function"		"bvo_toshiro_skill_5_main"
+						"multi"			"%hero_multi"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_toshiro_skill_5_freeze"
+						"Target" 		"TARGET"
+						"Duration"		"4.0"
+					}
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Radius" 	"500"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_toshiro.lua"
+								"Function"		"bvo_toshiro_skill_5_damage"
+								"multi"			"%hero_multi"
+							}
+							"ApplyModifier"
+							{
+								"ModifierName"	"bvo_toshiro_skill_5_slow"
+								"Target" 		"TARGET"
+								"Duration"		"2.0"
+							}
+						}
+					}
+				}
+			}
+
+			"bvo_toshiro_skill_5_slow"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50"
+				}
+			}
+
+			"bvo_toshiro_skill_5_freeze"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model"  "models/heroes/crystal_maiden/crystal_maiden_ice.vmdl"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_winter_wyvern.vsndevts"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+		}
+	}
+
+	"bvo_toshiro_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_toshiro_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"700"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"150.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"hero_multi"					"30 60 90 120 150"
+			}
+		}
+	}
+
+	//Rukia
+	"bvo_rukia_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"7.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"350"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175"
+		"AbilityCooldown"						"11.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"175 280 385 490 595 700"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse_drop.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Ancient_Apparition.ColdFeetCast"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"350"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_rukia_skill_1_freeze"
+						"Target" 		"TARGET"
+						"Duration"		"1.45"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rukia_skill_1_freeze"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+			"particle"  "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse_drop.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"300"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRange"						"700"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"0.60"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityChannelTime"					"1.2"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175"
+		"AbilityCooldown"						"18.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"600 700 800 900 1000"
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_2"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ObsidianDestroyer.SanityEclipse.Cast"
+				"Target"		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_2_hit"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"300"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_rukia.lua"
+						"Function"		"bvo_rukia_skill_2_damage"
+						"damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_rukia_skill_2_stun"
+						"Target" 		"TARGET"
+						"Duration"		"1.4"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rukia_skill_2_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_sanity_eclipse_area.vpcf"
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_arcane_orb.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_obsidian_destroyer.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"1200"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"0.2"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityChannelTime"					"3.0"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"40.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"300 450 600 750 900"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_3"
+				"Target" 		"CASTER"
+				"Duration"		"3.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_3_reset"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_3"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_3"
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_3"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_3"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_3_freeze"
+				"Target" 		"TARGET"
+				"Duration"		"3.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tusk.IceShards.Projectile"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rukia_skill_3"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"ThinkInterval"  "0.95"
+				"OnIntervalThink"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_rukia_skill_3_stack"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_rukia_skill_3_stack"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_rukia.lua"
+						"Function"		"bvo_rukia_skill_3_stack"
+					}
+				}
+			}
+
+			"bvo_rukia_skill_3_freeze"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+			"particle"  "particles/units/heroes/hero_tusk/tusk_ice_shards_projectile.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_tusk.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1.0"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"50 46 42 38 34"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 225 250 275 300"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"30 31 32 33 34"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"30.1 31.1 32.1 33.1 34.1"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"bvo_rukia_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Ancient_Apparition.ChillingTouchCast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rukia_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+				"EffectAttachType"	"attach_attack1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%damage"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_rukia.lua"
+						"Function"		"bvo_rukia_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"150"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1.0"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"45.0"
+		"AbilityDuration"						"15"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"100 125 150 175 200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"4.0 4.25 4.5 4.75 5.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_5"
+				"Target" 		"TARGET"
+				"Duration"		"15.0"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rukia_skill_5_freeze"
+				"Target" 		"TARGET"
+				"Duration"		"1.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Ancient_Apparition.IceVortexCast"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rukia_skill_5"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_ice_blast_debuff.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_rukia.lua"
+						"Function"		"bvo_rukia_skill_5"
+					}
+				}
+
+				"OnAttacked"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_rukia.lua"
+						"Function"		"bvo_rukia_skill_5_hit"
+						"damage"		"%damage"
+						"multi"			"%agi_multi"
+					}
+				}
+			}
+
+			"bvo_rukia_skill_5_freeze"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_ice_blast_debuff.vpcf"
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+			"particle"  "particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lich.vsndevts"
+		}
+	}
+
+	"bvo_rukia_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_rukia_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1.0"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"45.0"
+		"AbilityDuration"						"15"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"100 125 150 175 200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"4.0 4.25 4.5 4.75 5.0"
+			}
+		}
+	}
+
+	//Hollow
+	"bvo_hollow_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"7.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_hollow.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 120 140 160 180 200"
+		"AbilityCooldown"						"11.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "800"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile"  "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_1_bankai"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 120 140 160 180 200"
+		"AbilityCooldown"						"11.0"
+		"AbilityCastRange"						"1200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"300 495 690 885 1080 1275"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "1200"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile"  "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"11.0"
+		"AbilityManaCost"				"110"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 300 400 500 600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_hollow.lua"
+				"Function"					"bvo_hollow_skill_2"
+				"damage"					"%damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_hollow_skill_2_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"0.6"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_hollow_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_lancer.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"600"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"80"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"3"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"300"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"110"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.4"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_cd"					"3"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_hollow_skill_3_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.100000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%bonus_e_ms"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+				}
+
+				"EffectName"		"particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_hollow.lua"
+						"Function"		"bvo_hollow_skill_3_end"
+					}
+				}
+			}
+
+			"bvo_hollow_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-20" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Terrorblade.Metamorphosis"
+				"Target"			"CASTER"
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"200"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_hollow_skill_3_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.0"
+					}
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_hollow.lua"
+				"Function"		"bvo_hollow_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_hollow_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/events/ti5/teleport_start_lvl2_black_ti5.vpcf"
+			"model"	"models/hero_hollow/hero_hollow_bankai_base"
+			"particle"  "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_terrorblade.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_4"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		"AOERadius"								"400"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"800"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+
+		"AbilityCooldown"				"58.0"
+		"AbilityManaCost"				"350"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"leap_acceleration"		"7000.0"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"1000 1200 1400 1600 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_hollow.lua"
+				"Function"		"Leap"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_hollow.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			    "VerticalControlFunction" 	"LeapVertical"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Rubick.Telekinesis.Cast"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_rubick.vsndevts"
+		}
+	}
+
+	"bvo_hollow_skill_4_extra"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_hollow_skill_4"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+
+		"AbilityCastPoint"				"0.0"
+
+		"AbilityCooldown"				"0.0"
+		"AbilityManaCost"				"0"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage"				"1000 1200 1400 1600 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+				"EffectAttachType" 	"follow_origin"
+				"EffectRadius"		"400"
+				"Target" 			"CASTER"
+				"ControlPoints"
+				{
+					"01"	"400 0 400"
+				}
+			}
+
+			"FireSound"
+			{
+				"EffectName"		"Hero_Centaur.HoofStomp"
+				"Target" 			"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"400"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_hollow_skill_4_extra_stun"
+						"Target" 		"TARGET"
+						"Duration"		"1.75"
+					}
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PHYSICAL"
+						"Damage"		"%damage"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_hollow_skill_4_extra_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"particle"	"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_hollow_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityTextureName"					"icons/bvo_hollow_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"150.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"4 5 6 7 8"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"gt_damage"				"300 495 690 885 1080"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"3"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"2.0 2.5 3.0 3.5 4.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_hollow_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"Duration"			"%duration"
+
+				"EffectName"		"particles/dark_smoke_test.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_hollow_skill_5_modifier"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_hollow.lua"
+				"Function"		"bvo_hollow_skill_5"
+				"jumps"			"%jumps"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/dark_smoke_test.vpcf"
+		}
+	}
+
+	"bvo_hollow_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityTextureName"					"icons/bvo_hollow_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"150.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"4 5 6 7 8"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"gt_damage"				"300 495 690 885 1080"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"str_multi"				"3"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"2.0 2.5 3.0 3.5 4.0"
+			}
+		}
+	}
+
+	"bvo_hollow_skill_5_extra"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityTextureName"					"icons/bvo_ichigo_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"0.0"
+		"AbilityCastRange"						"1200"
+		"AbilityCastRangeBuffer"				"0"
+		"AbilityChannelTime"					"0.0 0.0 0.0 0.0 0.0 0.0"
+		"AbilityChannelledManaCostPerSecond"	"0 0 0 0 0 0"
+		"AbilityDuration"						"0.0 0.0 0.0 0.0 0.0 0.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"300 495 690 885 1080"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "1200"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile"  "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	//Lucci
+	"bvo_lucci_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_lucci.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_lucci_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 115 130 145 160 175"
+		"AbilityCooldown"						"9.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_bankai"					"75 85 95 105 115 125"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_lucci.lua"
+				"Function"		"bvo_lucci_skill_1"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DeathProphet.CarrionSwarm"
+				"Target"		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_lucci.lua"
+				"Function"		"bvo_lucci_skill_1_damage"
+				"damage" 		"%damage_bankai"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/econ/items/death_prophet/death_prophet_acherontia/death_prophet_acher_swarm.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+	}
+
+	"bvo_lucci_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"11.0"
+		"AbilityManaCost"				"160"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 275 350 425 500"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_lucci.lua"
+				"Function"					"bvo_lucci_skill_2"
+				"damage"					"%damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_lucci_skill_2_slow_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.0"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_lucci_skill_2_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-40" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_lancer.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_lucci_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"38.0"
+		"AbilityManaCost"				"250"
+		"AbilityDuration"				"4 5 6 7 8"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"4 5 6 7 8"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_lucci_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Abaddon.AphoticShield.Cast"
+				"Target"        "CASTER"  
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_lucci_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"StatusEffectName" 		"particles/status_fx/status_effect_medusa_stone_gaze.vpcf"
+				"StatusEffectPriority"  "10"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "40"
+				}
+
+				"OnAttacked"
+				{
+					"Random"
+					{
+						"Chance"			"20"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_lucci.lua"
+								"Function"		"bvo_lucci_skill_3_damage"
+							}
+
+							"RemoveModifier"
+							{
+								"Target"			"TARGET"
+								"ModifierName"		"modifier_knockback"
+							}
+
+							"Knockback"
+							{
+								"Target"            "ATTACKER"
+								"Center" 	        "CASTER"
+								"Distance"	        "140"
+								"Duration"	        "0.1"
+								"Height"	        "0"
+								"IsFixedDistance"	"1"
+								"ShouldStun"        "1"	
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/status_fx/status_effect_medusa_stone_gaze.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_abaddon.vsndevts"
+		}
+	}
+
+	"bvo_lucci_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"40 50 60 70 80"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"2"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"300"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"60 70 80 90 100"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.1"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_regen"					"7"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_lucci_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.100000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%bonus_e_ms"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "%bonus_regen"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_lucci.lua"
+						"Function"		"bvo_lucci_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_lucci.lua"
+				"Function"		"bvo_lucci_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_lucci_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"Target"					"CASTER"
+				"EffectName"				"Hero_Ursa.Overpower"
+			}
+		}
+
+		"precache"
+		{
+			"model"	"models/hero_lucci/hero_lucci_leo_base.vmdl"
+			"soundfile"						"soundevents/game_sounds_heroes/game_sounds_ursa.vsndevts"
+		}
+	}
+
+	"bvo_lucci_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_lucci_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"120.0"
+		"AbilityManaCost"				"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"level_multi"		"35 70 105 140 175"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_lucci.lua"
+				"Function"					"bvo_lucci_skill_5"
+				"multi"						"%level_multi"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_lucci_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"1.5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_lucci_skill_5_modifier_enemy"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_ATTACK2"
+			}
+		}
+		
+		"Modifiers"
+		{
+
+			"bvo_lucci_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_lucci_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-100" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_huskar.vsndevts"
+		}
+	}
+
+	//Moria
+	"bvo_moria_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_skill_0"
+		
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_moria_skill_0_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"ThinkInterval"	"0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_skill_0"
+						"modifier"		"bvo_moria_skill_0_buff_modifier"
+					}
+				}
+			}
+
+			"bvo_moria_skill_0_buff_modifier"
+			{
+				"IsHidden"	"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE"	"25"
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT"	"25"
+				}
+			}
+
+			"bvo_moria_skill_0_int_aura_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"Aura"        "bvo_moria_skill_0_int_aura_effect_modifier"
+				"Aura_Radius" "1000"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO"
+			}
+
+			"bvo_moria_skill_0_int_aura_effect_modifier"
+			{
+				"IsDebuff" "1"
+				"IsHidden"	"1"
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_skill_0_stack"
+						"modifier"		"bvo_moria_skill_0_int_modifier_bonus"
+					}
+				}
+			}
+
+			"bvo_moria_skill_0_int_modifier_bonus"
+			{
+				"IsHidden"	"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_STATS_INTELLECT_BONUS" "1"
+				}
+			}
+		}
+	}
+
+	// Rewrite of Death Prophet Exorcism
+	// Author: Noya
+	// Date: 01.02.2015.
+	// Note: The Targeting & Movement AI is "smarter" than the original ability, so the overall DPS is way higher when all spirits focus the same target
+	// To go around this, there is a min_time_between_attacks value which if it isn't reached after returning to the hero, the spirit will idle
+	"bvo_moria_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"	
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_moria_skill_1"
+
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+		
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastPoint"				"0.5"
+
+		// Time		
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCooldown"				"18.0"
+		"AbilityDuration"				"8.0"
+
+		// Cost
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityManaCost"				"250"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"radius"				"700"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"spirits"				"8 12 16 20 24 28"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"spirit_speed"			"500"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"max_distance"			"2000"
+			}
+			"05"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"give_up_distance"		"1200"
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_damage"			"40 40 40 40 40"
+			}
+			"07"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"max_damage"			"50 50 50 50 50"
+			}
+			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"heal_percent"			"25 25 25 25 25"
+			}
+			"09"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"average_damage"		"45 45 45 45 45"
+			}
+			// Extra
+			"10"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"duration"				"8"	//Always have a duration AbilitySpecial, don't believe Valves lies.
+			}
+			"11"	
+			{
+				"var_type"					"FIELD_FLOAT"
+				"delay_between_spirits"		"0.9"
+			}
+			"12"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"min_time_between_attacks"	"1.0"
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/items/death_prophet/exorcism/awakened_thirst_bats/awakened_thirst_bats"
+			"particle"  "particles/units/heroes/hero_death_prophet/death_prophet_exorcism_attack.vpcf"
+			"particle"  "particles/units/heroes/hero_death_prophet/death_prophet_exorcism_attack_building.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_moria.lua"
+				"Function"		"ExorcismDeath"
+			}
+
+			"RemoveModifier"
+			{
+				"ModifierName"	"modifier_exorcism"
+				"Target" 		"CASTER"
+			}
+
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_exorcism"
+				"Target" 		"CASTER"
+				"Duration"		"%AbilityDuration"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_DeathProphet.Exorcism.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_exorcism"
+			{	
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"ExorcismStart"
+					}
+
+					"FireSound"
+					{
+						"EffectName"	"Hero_DeathProphet.Exorcism"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackStart"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"ExorcismAttack"
+					}
+				}
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"ExorcismDeath"
+					}
+
+					"FireSound"
+					{
+						"EffectName"	"Hero_DeathProphet.Death"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"ExorcismEnd"
+					}
+				}
+			}
+
+			"modifier_exorcism_spirit"
+			{	
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"ExorcismPhysics"
+					}
+				}
+		
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FLYING"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+	}
+
+	"bvo_moria_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_CREEP"
+		"AbilityUnitTargetFlags"		"DOTA_UNIT_TARGET_FLAG_NOT_CREEP_HERO"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_moria_skill_2"
+		
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"						"5"
+		"RequiredLevel"					"3"
+		"LevelsBetweenUpgrades"			"4"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"36.0 32.0 28.0 24.0 20.0"
+		"AbilityManaCost"				"250 300 350 400 450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"800 1200 1600 2000 2400"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"copys"				"1 1 2 2 3"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"20 25 30 35 40"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_enigma/enigma_demonic_conversion.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_moria.lua"
+				"Function"		"bvo_moria_skill_2"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_moria_skill_2_end_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_skill_2_end"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" 			"models/hero_moria/hero_shadow_base.vmdl"
+			"particle"  		"particles/units/heroes/hero_enigma/enigma_demonic_conversion.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_enigma.vsndevts"
+		}
+	}
+
+	"bvo_moria_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_moria_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"800"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AbilityCooldown"						"45.0"
+		"AbilityManaCost"						"200 250 300 350 400"
+		"AbilityChannelTime"					"2 3 4 5 6"
+		"AbilityChannelledManaCostPerSecond" 	"50 65 80 95 110"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"2 3 4 5 6"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Bane.FiendsGrip.Cast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_moria_skill_3_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+		}
+		
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_moria_skill_3_modifier"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_moria_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_bane/bane_fiends_grip.vpcf"
+				"EffectAttachType"	"attach_origin"
+
+				"ThinkInterval"  "0.95"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"	"TARGET"
+						"Type"		"DAMAGE_TYPE_PURE"
+						"Damage"	"250"
+					}
+					"Heal"
+					{
+						"Target"        "CASTER"
+						"HealAmount"	"250"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Bane.BrainSap.Target"
+						"Target" 		"TARGET"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Bane.BrainSap"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"Heal"
+			{
+				"Target"        "TARGET"
+				"HealAmount"	"250"
+			}
+		}
+
+		"precache"
+		{
+			"particle"		"particles/units/heroes/hero_bane/bane_fiends_grip.vpcf"
+			"particle"  	"particles/units/heroes/hero_vengeful/vengeful_magic_missle.vpcf"
+		}
+	}
+
+	"bvo_moria_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_skill_4"
+		
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		// Stats
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastPoint"				"0.3"
+		"AbilityCooldown"				"200"
+		"AbilityManaCost"				"750"
+
+		// Precache
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_nightstalker.vsndevts"
+			"particle"			"particles/units/heroes/hero_night_stalker/nightstalker_ulti.vpcf"
+			"particle" 			"particles/units/heroes/hero_night_stalker/nightstalker_night_buff.vpcf"
+			"particle"			"particles/units/heroes/hero_night_stalker/nightstalker_void.vpcf"
+		}
+			
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"duration"				"60 70 80 90 100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Nightstalker.Darkness"
+				"Target"		"CASTER"
+			}
+
+			"FireEffect"
+			{
+				"EffectName"	"particles/units/heroes/hero_night_stalker/nightstalker_ulti.vpcf"
+				"EffectAttachType"	"follow_origin"
+				"Target"		"CASTER"
+			}
+
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_moria.lua"
+				"Function"		"Darkness"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_hunter_in_the_night_datadriven"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"ThinkInterval"	"0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"HunterInTheNight"
+						"modifier"		"modifier_hunter_in_the_night_buff_datadriven"
+					}
+				}
+			}
+
+			"modifier_hunter_in_the_night_buff_datadriven"
+			{
+				"IsHidden"	"1"
+
+				"EffectName"	"particles/units/heroes/hero_night_stalker/nightstalker_night_buff.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Aura"        "modifier_bvo_moria_skill_4_slow"
+				"Aura_Radius" "700"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"30"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_moria.lua"
+								"Function"		"bvo_moria_skill_4_damage"
+							}
+							"ApplyModifier"
+							{
+								"ModifierName"	"modifier_void_datadriven"
+								"Target" 		"TARGET"
+								"Duration"		"1.0"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			"modifier_bvo_moria_skill_4_slow"
+			{
+				"IsDebuff" "1"
+				"IsHidden"	"1"
+
+				"Properties" 
+				{
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE"	"-35"
+				}
+			}
+
+			"modifier_void_datadriven"
+			{
+				"IsHidden"	"1"
+
+				"EffectName"	"particles/units/heroes/hero_night_stalker/nightstalker_void.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_moria_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_skill_5"
+		
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+		// Stats
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastPoint"				"0.3"
+		"AbilityCooldown"				"120"
+		"AbilityManaCost"				"900"
+			
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"bonus_damage"			"75 100 125 150 175"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"armor"					"9 10 12 13 15"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"hp_regen"				"10 15 20 25 30"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Terrorblade.Metamorphosis"
+				"Target"			"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_terrorblade/terrorblade_metamorphosis_transform.vpcf"
+				"EffectAttachType"	"follow_origin"
+				"Target"			"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_moria_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"60.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_moria_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName" 		"particles/units/heroes/hero_terrorblade/terrorblade_metamorphosis.vpcf"
+				"EffectAttachType"  "follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_skill_5"
+					}
+				}
+			
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_skill_5_end"
+					}
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT" "%hp_regen"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%armor"
+					"MODIFIER_PROPERTY_DAMAGEOUTGOING_PERCENTAGE" "%bonus_damage"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_terrorblade/terrorblade_metamorphosis_transform.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_terrorblade.vsndevts"
+			"particle"  "particles/units/heroes/hero_terrorblade/terrorblade_metamorphosis.vpcf"
+		}
+	}
+
+	//Moria - Doppelman
+	"bvo_moria_dpl_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_dpl_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_moria_dpl_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_dpl_skill_0"
+					}
+				}
+
+				"OnAttackStart"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Bane.Attack"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_moria.lua"
+				"Function"		"bvo_moria_dpl_skill_0_heal"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Bane.BrainSap"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_vengeful/vengeful_magic_missle.vpcf"
+		}
+	}
+
+	"bvo_moria_dpl_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_dpl_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCooldown"				"6.0"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_moria.lua"
+				"Function"		"bvo_moria_dpl_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_vengefulspirit.vsndevts"
+		}
+	}
+
+	"bvo_moria_dpl_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_dpl_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCooldown"				"5.0"
+		"AbilityManaCost"				"65"
+
+		"OnSpellStart"
+		{
+			"SpawnUnit"
+			{
+				"UnitName"		"npc_dota_shadow_bat"
+				"Target" 		"CASTER"
+				"Duration"		"15.0"
+				"UnitCount"		"1"
+				"UnitLimit"		"0"
+				"GrantsGold"	"0"
+				"GrantsXP"		"0"
+				"SpawnRadius"	"100"
+				"OnSpawn"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_phased"
+						"Target"		"TARGET"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_dpl_skill_2"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Visage.SummonFamiliars.Cast"
+						"Target" 		"TARGET"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_moria_dpl_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"ThinkInterval"  "2.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_dpl_skill_2_auto"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_visage.vsndevts"
+		}
+	}
+
+	"bvo_moria_dpl_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_dpl_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_moria_dpl_skill_3_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_moria.lua"
+						"Function"		"bvo_moria_dpl_skill_3"
+					}
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Radius" 	"750"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_moria.lua"
+								"Function"		"bvo_moria_dpl_skill_3_damage"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_queenofpain/queen_scream_of_pain_owner.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_techies.vsndevts"
+		}
+	}
+
+	"bvo_moria_dpl_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_moria_dpl_skill_4"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"Modifiers"
+		{
+			"bvo_moria_dpl_skill_4_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnAttackLanded"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_moria_dpl_skill_4_hit_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"3.0"
+					}
+				}
+			}
+
+			"bvo_moria_dpl_skill_4_hit_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "-5"
+				}
+			}
+		}
+	}
+
+	//Sanji
+	"bvo_sanji_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"8.0"
+		"AbilityManaCost"				"30"
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sanji_skill_0_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"4.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Dark_Seer.Surge"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sanji_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"EffectName"		"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+				"EffectAttachType"	"follow_hitloc"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "25"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "650"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"			"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_dark_seer.vsndevts"
+		}
+	}
+
+	"bvo_sanji_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_1"
+		"AOERadius"							"300"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"11.0"
+		"AbilityManaCost"				"80 100 120 140 160 180"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"2.0 2.5 3.0 3.5 4.0 4.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"300"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sanji.lua"
+						"Function"		"bvo_sanji_skill_1"
+						"multi"			"%agi_multi"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_sanji_skill_1_stun_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"1.0"
+					}
+					"ApplyMotionController"
+					{
+					    "Target" 		"TARGET"
+					    "ScriptFile"    "heroes/ability_sanji.lua"
+					    "HorizontalControlFunction" "KnockbackTarget"
+					}
+				}
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_counter_helix_datadriven"
+				"Target" 		"CASTER"
+				"Duration"		"0.15"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_sanji_skill_1_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"modifier_counter_helix_datadriven"
+			{
+				"IsHidden"		"1"
+
+				"EffectName"	"particles/units/heroes/hero_axe/axe_attack_blur_counterhelix.vpcf"
+				"EffectAttachType"	"follow_origin"			
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Axe.CounterHelix"
+						"Target" 		"CASTER"
+					}
+
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_counter_helix_rotate_datadriven"
+						"Target" 		"CASTER"
+						"Duration"		"0.15"
+					}
+				}
+			}
+
+			"modifier_counter_helix_rotate_datadriven"
+			{
+				"IsHidden"	"1"
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 72 0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_axe.vsndevts"
+			"particle"			"particles/units/heroes/hero_axe/axe_attack_blur_counterhelix.vpcf"
+		}
+	}
+
+	"bvo_sanji_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"150"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"32.0 29.0 26.0 23.0 20.0"
+		"AbilityManaCost"				"200"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_2"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"TARGET"
+			    "ScriptFile"    "heroes/ability_sanji.lua"
+			    "HorizontalControlFunction" "KnockbackTarget2"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sanji_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_sanji_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"60.0"
+		"AbilityManaCost"				"300"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"60"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"armor"				"3"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"health"			"300"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"ms"				"100"
+			}
+			"06"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"bat"				"0.16"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sanji_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sanji_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "60"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "3"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.050000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "100"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "300"
+				}
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_DoomBringer.ScorchedEarthAura"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"EffectName"		"particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sanji.lua"
+						"Function"		"bvo_sanji_skill_3_end"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_doombringer.vsndevts"
+		}
+	}
+
+	"bvo_sanji_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"1200"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"80.0 75.0 70.0 65.0 60.0"
+		"AbilityManaCost"				"300"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_4"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DragonKnight.BreathFire"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_4_damage"
+			}
+		}
+
+		"OnProjectileFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_4_clear"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_dragon_knight.vsndevts"
+		}
+	}
+
+	"bvo_sanji_skill_4_off"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"1200"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"80.0 75.0 70.0 65.0 60.0"
+		"AbilityManaCost"				"300"
+	}
+
+	"bvo_sanji_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"110.0"
+		"AbilityManaCost"				"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"multi"				"10 20 30 40 50"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"1000 1500 2000 2500 3000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sanji.lua"
+				"Function"		"bvo_sanji_skill_5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sanji_skill_5_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"TARGET"
+			    "ScriptFile"    "heroes/ability_sanji.lua"
+			    "HorizontalControlFunction" "KnockbackTarget3"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_FacelessVoid.TimeWalk"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sanji_skill_5_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sanji.lua"
+						"Function"		"bvo_sanji_skill_5_damage"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_light_strike_array_explosion.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_faceless_void.vsndevts"
+		}
+	}
+
+	"bvo_sanji_skill_5_off"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sanji_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"110.0"
+		"AbilityManaCost"				"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"level_multi"		"10 20 30 40 50"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"1000 2000 3000 4000 5000"
+			}
+		}
+	}
+
+	//Usopp
+	"bvo_usopp_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"55.0"
+		"AbilityManaCost"				"175"
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Medusa.ManaShield.On"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_usopp_skill_0_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"3.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_0_stop"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_medusa/medusa_mana_shield.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/usopp/ability_usopp_0.lua"
+						"Function"		"bvo_usopp_skill_0_damage"
+						"damage"		"%attack_damage"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_0_switch"
+					}
+				}
+
+				"ThinkInterval"		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/usopp/ability_usopp_0.lua"
+						"Function"		"bvo_usopp_skill_0_track"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_medusa/medusa_mana_shield.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_medusa.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_0_use"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_0_use"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"150"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"55.0"
+		"AbilityManaCost"				"200"
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Techies.Suicide"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_techies/techies_suicide_base.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_0_use"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_usopp_skill_0_use_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"0.9"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"TARGET"
+			    "ScriptFile"    "heroes/ability_usopp.lua"
+			    "HorizontalControlFunction" "KnockbackTarget"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_usopp_skill_0_use_stun_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"0.3"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_usopp.lua"
+			    "HorizontalControlFunction" "KnockbackTarget"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_0_use_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_techies/techies_suicide_base.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_techies.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_1"
+		"AOERadius"							"250"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.2"//0.3
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"12.0"
+		"AbilityManaCost"				"220"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"burn_dps"			"55 70 90 110 135 160"
+			}
+		}
+
+		"OnAbilityPhaseStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_1_sound"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_1"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Lina.attack"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_fire_spirit_burn.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PURE"
+						"Damage"		"%burn_dps"
+					}
+				}
+			}
+
+			"bvo_usopp_skill_1_sound_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_1_stop"
+					}
+				}
+			}
+		}
+
+		"OnProjectileFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_1_hit"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_batrider/batrider_flamebreak.vpcf"
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_fire_spirit_burn.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_batrider.vsndevts"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"bonus_damage"		"5 10 15 20 25"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_2_boni_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE" "%bonus_damage"
+				}
+
+				"OnAttackStart"
+				{
+					"Random"
+					{
+						"Chance"			"7"
+						"PseudoRandom" 		"DOTA_PSEUDO_RANDOM_JUGG_CRIT"
+						"OnSuccess"
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"bvo_usopp_skill_2_modifier"
+								"Target" 		"CASTER"
+								"Duration"		"%duration"
+							}
+							"FireSound"
+							{
+								"EffectName"	"Hero_Sniper.ShrapnelShoot"
+								"Target" 		"CASTER"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			"bvo_usopp_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "1000"
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_2"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_sniper.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_3"
+		"AOERadius"							"250"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"18.0"
+		"AbilityManaCost"				"250"
+		"AbilityChannelTime"			"2.1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"600 900 1200 1500 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_usopp_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"2.1"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_3"
+				"Target"		"POINT"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_usopp_skill_3_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "0.35"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_3_cast"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Lina.attack"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_usopp_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_3_hit"
+				"damage"		"%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_batrider/batrider_flamebreak.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_batrider.vsndevts"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"//0.55
+		"AbilityCastRange"				"2000"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"70.0"
+		"AbilityManaCost"				"350"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"agi_multi"			"8 9 10 11 12"
+			}
+		}
+
+		"OnAbilityPhaseStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_4_sound"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_4_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_4_stop"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_phoenix/phoenix_fire_spirit_launch_model.vpcf"
+				"MoveSpeed"		 "2000"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "2000"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "1"
+			    "VisionRadius" 	 "250"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+				"MoveSpeed"		 "2000"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "2000"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_NONE"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_NONE"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "1"
+			    "VisionRadius" 	 "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Lina.DragonSlave"
+				"Target" 		"CASTER"
+			}
+			
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_4_hit"
+				"multi"			"%agi_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_fire_spirit_launch_model.vpcf"
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_5"
+		"AOERadius"							"450"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"//0.6
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"130.0 120.0 110.0 100.0 90.0"
+		"AbilityManaCost"				"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"burn_hp_dmg"		"3 4 5 6 7"
+			}
+		}
+
+		"OnAbilityPhaseStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_5_sound"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_5_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_5_stop"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_5"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Lina.attack"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+		}
+
+		"OnProjectileFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_5_hit"
+			}
+			"FireEffect"
+			{
+				"EffectName"	"particles/units/heroes/hero_lina/lina_spell_light_strike_array.vpcf"
+				"EffectAttachType"	"start_at_customorigin"
+				"TargetPoint"		"POINT"
+
+				"ControlPoints"
+	            {
+	            	"00"	"POINT"
+	            	"01"	"450 0 0"
+	            	"03"	"0 0 0"
+	            }
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_batrider/batrider_flamebreak.vpcf"
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_light_strike_array.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_usopp_skill_5_extra"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_usopp_skill_5"
+		"AOERadius"							"450"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"130.0 120.0 110.0 100.0 90.0"
+		"AbilityManaCost"				"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"burn_hp_dmg"		"3 4 5 6 7"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_usopp_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_phoenix/phoenix_fire_spirit_burn.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_usopp.lua"
+						"Function"		"bvo_usopp_skill_5_damage"
+						"multi"			"%burn_hp_dmg"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_usopp.lua"
+				"Function"		"bvo_usopp_skill_5_hit2"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"particle"  "particles/units/heroes/hero_phoenix/phoenix_fire_spirit_burn.vpcf"
+		}
+	}
+
+	//Nami
+	"bvo_nami_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_nami_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"1000"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"11.0"
+		"AbilityManaCost"				"200"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"int_multi"			"5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"Target"						"CASTER"
+				"EffectName"					"Hero_StormSpirit.BallLightning"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_0"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_0_damage"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_stormspirit.vsndevts"
+			"particle"  "particles/units/heroes/hero_stormspirit/stormspirit_ball_lightning.vpcf"  
+		}
+	}
+
+	"bvo_nami_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_nami_skill_1"
+		"AOERadius"							"275"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.4"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"8.5"
+		"AbilityManaCost"				"180"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"225 340 455 570 685 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_leshrac/leshrac_split_earth.vpcf"
+				"EffectAttachType"  "start_at_customorigin"
+				"TargetPoint"       "POINT"
+
+				"ControlPoints"
+				{
+					"01"    "275 275 275"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Leshrac.Split_Earth"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"275"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_nami_skill_0_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.5"
+					}
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_1"
+				"Target"		"POINT"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_nami_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "-30"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-30" 
+				}
+
+				"EffectName"		"particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_disruptor/disruptor_thunder_strike_bolt.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_leshrac.vsndevts"
+			"particle"  "particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_laguna_blade.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_nami_skill_1_extra"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_BOTH"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_ALL"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_nami_skill_1"
+		"AOERadius"							"275"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCooldown"				"0.0"
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"	"particles/units/heroes/hero_lina/lina_spell_laguna_blade.vpcf"
+				"EffectAttachType"	"start_at_customorigin"
+
+				"ControlPointEntities"
+				{
+					"CASTER"	"attach_attack1"
+					"TARGET"	"attach_hitloc"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_nami_skill_1_smoke_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"EffectName"		"particles/dark_smoke_test.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_laguna_blade.vpcf"
+			"particle"  "particles/dark_smoke_test.vpcf"
+		}
+	}
+
+	"bvo_nami_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_nami_skill_2"
+		"AOERadius"							"800"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"250"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"1.0 1.5 2.0 2.5 3.0"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"100 150 200 250 300"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_2"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Slark.ShadowDance"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_nami_skill_2_smoke_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"EffectName"		"particles/dark_smoke_test.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+
+			"bvo_nami_skill_2_damage_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Radius" 	"800"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_nami.lua"
+								"Function"		"bvo_nami_skill_2_damage"
+								"multi"			"%int_multi"
+								"damage"		"%damage"
+							}
+							"FireSound"
+							{
+								"EffectName"	"Hero_Zuus.GodsWrath.Target"
+								"Target" 		"TARGET"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/dark_smoke_test.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_slark.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_zuus.vsndevts"
+			"particle"  "particles/econ/items/sven/sven_warcry_ti5/sven_warcry_cast_arc_lightning.vpcf"
+		}
+	}
+
+	"bvo_nami_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_nami_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastPoint"				"0.2"
+
+		// Time		
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCooldown"				"40"
+
+		// Cost
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityManaCost"				"300"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"illusion_duration"			"30"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"outgoing_damage"			"-80 -78 -76 -74 -72"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"outgoing_damage_tooltip"	"20 22 24 26 28"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"incoming_damage"			"120 110 100 90 80"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"tooltip_incoming_damage_total_pct"			"220 210 200 190 180"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"images_count"				"4"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"invuln_duration"			"0.05"
+			}
+		}
+		
+		// Data driven
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"particle"					"particles/units/heroes/hero_siren/naga_siren_mirror_image.vpcf"
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_phased"
+				"Target"		"CASTER"
+				"Duration"		"2.0"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_mirror_image"
+				"Target"		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_mirror_image"
+			{	
+				"Duration"			"%invuln_duration"
+				"IsHidden"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE" 			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_LOW_ATTACK_PRIORITY"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"		"particles/units/heroes/hero_siren/naga_siren_mirror_image.vpcf"
+						"EffectAttachType"	"follow_origin"
+						"Target"			"CASTER"
+					}
+			    }
+
+			    "OnDestroy"
+			    {
+			    	"RunScript"
+				    {
+				        "ScriptFile"    "heroes/ability_nami.lua"
+				        "Function"      "MirrorImage"
+				    }
+			    }
+			}
+		}
+	}
+
+	"bvo_nami_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_nami_skill_4"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"1800"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"70.0"
+		"AbilityManaCost"				"350"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"int_multi"					"8 10 12 14 16"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_invoker/invoker_tornado.vpcf"
+				"MoveSpeed"		 "1200"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "1800"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "300"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_4"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_4_damage"
+				"multi"			"%int_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_invoker/invoker_tornado.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_nami_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_nami_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"800"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"115.0"
+		"AbilityManaCost"				"600"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"int_multi"					"4 6 8 10 12"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"400 1000 1600 2200 2800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_5"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Zuus.ArcLightning.Cast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_nami_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"40.0"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_nami.lua"
+				"Function"		"bvo_nami_skill_5_damage"
+				"multi"			"%int_multi"
+				"damage"		"%damage"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_nami_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_zuus.vsndevts"
+		}
+	}
+
+	//Aokiji
+	"bvo_aokiji_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_0"
+		"AOERadius"						"%small_radius"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"25.0"
+		"AbilityManaCost"				"175"
+		"AnimationPlaybackRate"			"1"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"450"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"small_radius"				"350"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"activation_time"			"2.5"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"max_mines"					"1"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"fade_time"					"0.5"
+			}
+			// Extra
+			"06"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"vision_radius"				"300"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"vision_duration"			"1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tusk.FrozenSigil.Cast"
+				"Target" 		"CASTER"
+			}
+
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_aokiji.lua"
+				"Function"		"LandMinesPlant"
+				"Target"		"POINT"
+				"modifier_land_mine"	"modifier_land_mine_datadriven"
+				"modifier_tracker"		"modifier_land_mine_tracker_datadriven"
+				"modifier_caster"		"modifier_land_mine_caster_datadriven"
+				"modifier_land_mine_invisibility"	"modifier_land_mine_invisibility_datadriven"
+			}
+		}
+
+		"Modifiers"
+		{
+			"modifier_land_mine_datadriven"
+			{
+				"IsHidden"		"1"
+				"IsPurgable"	"0"
+
+				"OnDeath"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Ability.FrostNova"
+						"Target"
+						{
+							"Center"	"UNIT"
+							"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"UNIT"
+							"Radius" 	"%small_radius"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_BUILDING"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+						}
+					
+						"Action"    
+						{
+							"Damage"
+							{
+								"Target"		"TARGET"
+								"Type"			"DAMAGE_TYPE_MAGICAL"
+								"Damage"		"%damage"
+							}
+							"ApplyModifier"
+							{
+								"ModifierName"	"modifier_land_mine_freeze"
+								"Target" 		"TARGET"
+								"Duration"		"1.5"
+							}
+						}
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"LandMinesDeath"
+						"modifier_caster"	"modifier_land_mine_caster_datadriven"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"modifier_land_mine_tracker_datadriven"
+			{
+				"IsHidden"		"1"
+				"IsPurgable"	"0"
+
+				"EffectName"	"particles/units/heroes/hero_techies/techies_land_mine.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"LandMinesTracker"
+					}
+				}
+			}
+
+			"modifier_land_mine_caster_datadriven"
+			{
+				"IsDebuff"		"1"
+				"IsPurgable"	"0"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"LandMinesForceKill"
+					}
+				}
+			}
+
+			"modifier_land_mine_invisibility_datadriven"
+			{
+				"IsHidden"		"1"
+				"IsPurgable"	"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVISIBLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"modifier_land_mine_freeze"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_lich.vsndevts"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_tusk.vsndevts"
+			"particle"		"particles/units/heroes/hero_techies/techies_land_mine.vpcf"
+			"particle"		"particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+			"model"			"models/items/tuskarr/sigil/boreal_sigil/boreal_sigil.vmdl"
+		}
+	}
+
+	"bvo_aokiji_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"				"1200"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"14.0 13.0 12.0 11.0 10.0 9.0"
+		"AbilityManaCost"				"175"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"path_delay"				"0.5"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"duration"					"1.5"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"path_radius"				"150"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"225 340 455 570 685 800"
+			}
+		}
+		
+		// Data driven
+		//-------------------------------------------------------------------------------------------------------------
+		"precache"
+		{
+			"soundfile"					"soundevents/game_sounds_heroes/game_sounds_jakiro.vsndevts"
+			"particle"					"particles/units/heroes/hero_jakiro/jakiro_ice_path.vpcf"
+			"particle"					"particles/units/heroes/hero_jakiro/jakiro_ice_path_b.vpcf"
+		//	"particle"					"particles/units/heroes/hero_jakiro/jakiro_icepath_debuff.vpcf"
+		}
+		
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Jakiro.IcePath"
+				"Target"			"CASTER"
+			}
+			
+			"RunScript"
+			{
+				"ScriptFile"		"heroes/ability_aokiji.lua"
+				"Function"			"FireEffect_IcePath"
+				
+				"path_delay"		"%path_delay"
+				"duration"			"%duration"
+				"path_radius"		"%path_radius"
+			}
+			
+			"DelayedAction"
+			{
+				"Delay"		"0.1"
+				"Action"
+				{
+					"FireSound"
+					{
+						"EffectName"		"Hero_Jakiro.IcePath.Cast"
+						"Target"			"CASTER"
+					}
+				}
+			}
+			
+			"DelayedAction"
+			{
+				"Delay"		"%path_delay"
+				"Action"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"heroes/ability_aokiji.lua"
+						"Function"			"FireEffect_Destroy_IcePath_A"
+					}
+				}
+			}
+		}
+		
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"		"0"
+			
+			"RunScript"
+			{
+				"ScriptFile"		"heroes/ability_aokiji.lua"
+				"Function"			"ApplyDummyModifier"
+				"Target"			"TARGET"
+				
+				"modifier_name"		"modifier_ice_path_check_range_datadriven"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"modifier_ice_path_check_range_datadriven"
+			{
+				"IsHidden"		"1"
+				"IsPurgable"	"0"
+				
+				"ThinkInterval"	"0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"heroes/ability_aokiji.lua"
+						"Function"			"CheckIcePath"
+						"Target"			"TARGET"
+						
+						"path_radius"		"%path_radius"
+					}
+				}
+			}
+			
+			"modifier_ice_path_stun_datadriven"
+			{
+				"IsDebuff" 		"1"
+				"OverrideAnimation"		"ACT_DOTA_DISABLED"
+
+				"EffectName" "particles/generic_gameplay/generic_stunned.vpcf"
+	        	"EffectAttachType" "follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+				
+				"OnCreated"
+				{
+					"Damage"
+					{
+						"Target"	"TARGET"
+						"Type"		"DAMAGE_TYPE_MAGICAL"
+						"Damage"	"%damage"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_aokiji_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastAnimation"			"ACT_DOTA_IDLE"
+		"AbilityCastPoint"				"0.1"
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"200"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"duration"					"7 9 11 13 15"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"50 75 100 125 150"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aokiji_skill_2_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Ancient_Apparition.ChillingTouchCast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aokiji_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+				"EffectAttachType"	"attach_attack1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "40"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.100000"
+				}
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"20"
+						"OnSuccess"
+						{
+							"FireSound"
+							{
+								"EffectName"	"Ability.FrostNova"
+								"Target"
+								{
+									"Center"	"TARGET"
+									"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+								}
+							}
+							"ActOnTargets"
+							{
+								"Target"
+								{
+									"Center"  	"TARGET"
+									"Radius" 	"200"
+									"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+									"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+								}
+							
+								"Action"    
+								{
+									"Damage"
+									{
+										"Target"		"TARGET"
+										"Type"			"DAMAGE_TYPE_PURE"
+										"Damage"		"%damage"
+									}
+								}
+							}
+							"FireEffect"
+							{
+								"EffectName"        "particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+								"EffectAttachType"  "follow_origin"
+								"Target"
+								{
+									"Center"	"TARGET"
+									"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+								}
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lich.vsndevts"
+		}
+	}
+
+	"bvo_aokiji_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"600"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"250"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"duration"					"2.0 2.5 3.0 3.5 4.0"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"200 225 250 275 300"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aokiji_skill_3_freeze_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_aokiji.lua"
+				"Function"		"bvo_aokiji_skill_3"
+				"duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aokiji_skill_3_freeze_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_aokiji_skill_3_aura_modifier"
+			{
+				"Passive" "0"
+   				"IsHidden" "0"
+
+				"Aura"        "bvo_aokiji_skill_3_slow_modifier"
+				"Aura_Radius" "350"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"bvo_aokiji_skill_3_end"
+					}
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+					}
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse_ground.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+						"EffectRadius"		"350"
+						"ControlPoints"
+						{
+							"02"	"350 350 350"
+						}
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Ancient_Apparition.IceVortexCast"
+						"Target" 		"TARGET"
+					}
+				}
+			}
+
+			"bvo_aokiji_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-60" 
+				}
+
+				"ThinkInterval"  "0.5"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"bvo_aokiji_skill_3_damage"
+						"damage"		"%damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse.vpcf"
+			"particle"  "particles/units/heroes/hero_winter_wyvern/wyvern_winters_curse_ground.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+		}
+	}
+
+	"bvo_aokiji_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_4"
+		"AOERadius"						"350"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"82.0 74.0 66.0 58.0 50.0"
+		"AbilityManaCost"				"280"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"350"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_aokiji_skill_4_curse_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"10.0"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Ancient_Apparition.IceVortexCast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aokiji_skill_4_particle_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"0.3"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aokiji_skill_4_particle_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"1"
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_ancient_apparition/ancient_ice_vortex.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+
+						"ControlPoints"
+						{
+							"01"	"350 0 0"
+							"05"	"350 0 0"
+						}
+					}
+				}
+			}
+
+			"bvo_aokiji_skill_4_curse_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"StatusEffectName" 		"particles/status_fx/status_effect_iceblast.vpcf" 	   
+				"StatusEffectPriority"  "10"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"250"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Ability.FrostNova"
+						"Target"
+						{
+							"Center"	"TARGET"
+							"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_aokiji_skill_4_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"0.5"
+					}
+					"FireEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"
+						{
+							"Center"	"TARGET"
+							"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+				}
+
+				"OnDestroy"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_aokiji_skill_4_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"4.0"
+					}
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PURE"
+						"Damage"		"450"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Ancient_Apparition.ColdFeetFreeze"
+						"Target" 		"TARGET"
+					}
+				}
+			}
+
+			"bvo_aokiji_skill_4_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-30" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_ice_vortex.vpcf"
+			"particle"  "particles/units/heroes/hero_lich/lich_frost_nova.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lich.vsndevts"
+		}
+	}
+
+	"bvo_aokiji_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_aokiji_skill_5"
+		"AOERadius"						"1700"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"200.0"
+		"AbilityManaCost"				"550"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"lvl_multi"					"20 40 60 80 100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_aokiji.lua"
+				"Function"		"bvo_aokiji_skill_5_cast"
+				"multi"			"%lvl_multi"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aokiji_skill_5_stop_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"1.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aokiji_skill_5_dummy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"bvo_aokiji_skill_5_dummy"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_aokiji.lua"
+						"Function"		"bvo_aokiji_skill_5_dummy_end"
+					}
+				}
+			}
+
+			"bvo_aokiji_skill_5_stop_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_aokiji_skill_5_freeze_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_FROZEN"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_cold_feet_frozen.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"model"		"models/heroes/crystal_maiden/crystal_maiden_ice.vmdl"
+		}
+	}
+
+	//Yoruichi
+	"bvo_yoruichi_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75"
+		"AbilityCooldown"						"4.5"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_yoruichi_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"				"%distance"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"16.0"
+		"AbilityManaCost"				"150"
+		"AnimationPlaybackRate"			"3"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"agi_multi"					"4.0 4.5 5.0 5.5 6.0 7.5"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"distance"					"800 1000 1200 1400 1600 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yoruichi.lua"
+				"Function"		"bvo_yoruichi_skill_1"
+				"distance"		"%distance"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yoruichi_skill_1_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yoruichi.lua"
+				"Function"		"bvo_yoruichi_skill_1_damage"
+				"multi"			"%agi_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/puck/puck_merry_wanderer/puck_illusory_orb_merry_wanderer.vpcf"
+			"particle" "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_yoruichi_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_IDLE"
+		"AbilityCooldown"				"20.0 18.0 16.0 14.0 12.0"
+		"AbilityManaCost"				"175"
+		"AnimationPlaybackRate"			"1"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilityChannelTime"			"3.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"agi_multi"					"5"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"trigger"					"450"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"knockback"					"600"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"stun"						"0.85"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"agi_multi2"					"6"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"trigger2"					"600"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"knockback2"					"900"
+			}
+			"08"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"stun2"						"1.4"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"Target" 		"CASTER"
+				"ModifierName"	"bvo_yoruichi_skill_2_modifier"
+				"Duration"		"3.0"
+			}
+			"FireSound"
+			{
+				"Target" 		"CASTER"
+				"EffectName"	"Hero_Abaddon.AphoticShield.Cast"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yoruichi_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_abaddon/abaddon_borrowed_time.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"StatusEffectName"		"particles/status_fx/status_effect_abaddon_borrowed_time.vpcf"
+				"StatusEffectPriority"  "15"
+
+				"OnAttacked"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yoruichi.lua"
+						"Function"		"bvo_yoruichi_skill_2_hit_s"
+					}
+					"ApplyMotionController"
+					{
+						"Caster" 		"CASTER"
+					    "Target" 		"CASTER"
+					    "ScriptFile"    "heroes/ability_yoruichi.lua"
+					    "HorizontalControlFunction" "KnockbackTarget"       
+					}
+					"ApplyMotionController"
+					{
+						"Caster" 		"CASTER"
+					    "Target" 		"ATTACKER"
+					    "ScriptFile"    "heroes/ability_yoruichi.lua"
+					    "HorizontalControlFunction" "KnockbackTarget"       
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yoruichi.lua"
+						"Function"		"bvo_yoruichi_skill_2_hit"
+					}
+				}
+			}
+
+			"bvo_yoruichi_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_yoruichi_skill_2_stun2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_yoruichi_skill_2_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_abaddon/abaddon_borrowed_time.vpcf"
+			"particle"	"particles/status_fx/status_effect_abaddon_borrowed_time.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_yoruichi_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 150 200 250 300"
+		"AbilityCooldown"						"35.0"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"jumps"					"5 6 7 8 9"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"agi_multi"				"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yoruichi.lua"
+				"Function"		"bvo_yoruichi_skill_3"
+				"jumps"			"%jumps"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles\units\heroes\hero_nyx_assassin\nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	"bvo_yoruichi_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_agi"						"25"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_armor"					"4"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_health"				"350"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_e_ms"					"130"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bonus_e_bat"					"0.15"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_yoruichi_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_STATS_AGILITY_BONUS" "%bonus_agi"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonus_armor"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT" "1.100000"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%bonus_e_ms"
+					"MODIFIER_PROPERTY_HEALTH_BONUS" "%bonus_e_health"
+				}
+
+				"EffectName"		"particles/items2_fx/mjollnir_shield.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_yoruichi.lua"
+						"Function"		"bvo_yoruichi_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yoruichi.lua"
+				"Function"		"bvo_yoruichi_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_yoruichi_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.static.start"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items2_fx/mjollnir_shield.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_razor.vsndevts"
+		}
+	}
+
+	"bvo_yoruichi_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"130.0 125.0 120.0 115.0 110.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"agi_final"						"4 8 12 16 20"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_tick"						"0.5 0.6 0.75 0.9 1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_yoruichi.lua"
+				"Function"		"bvo_yoruichi_skill_5"
+			}
+		}
+	}
+
+	"bvo_yoruichi_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_yoruichi_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"130.0 125.0 120.0 115.0 110.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"agi_final"						"5 10 15 20 25"
+			}
+		}
+	}
+
+	//Shinobu
+	"bvo_shinobu_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_0"
+
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"						"1"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_IDLE"
+		"AbilityCooldown"				"6.0"
+		"AbilityManaCost"				"45"
+		"AnimationPlaybackRate"			"1"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"700"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_0"
+				"Target"		"POINT"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_shinobu_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_shinobu_skill_0_effect_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"EffectName"		"particles/econ/events/fall_major_2015/teleport_start_fallmjr_2015_lvl2_black_b.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_0_end"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/events/fall_major_2015/teleport_start_fallmjr_2015_lvl2_black_b.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_queenofpain.vsndevts"
+		}
+	}
+
+	"bvo_shinobu_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_1"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"14.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"205 310 415 520 625 730"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"heal"							"0.25"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"heal_tooltip"					"25"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"350"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"damage_x_heal"					"51.25 77.5 103.75 130 156.25 182.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Bane.BrainSap"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"		"particles/custom/shinobu/shinobu_skill_1.vpcf"
+				"EffectAttachType"	"follow_origin"
+				"Target"			"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+					"Heal"
+					{
+						"Target"        "CASTER"
+						"HealAmount"	"%damage_x_heal"//%damage * %heal
+					}
+					"FireEffect"
+					{
+						"EffectName"	"particles/units/heroes/hero_bane/bane_sap.vpcf"
+						"EffectAttachType"	"follow_origin"
+
+						"ControlPointEntities"
+						{
+							"CASTER" "follow_origin"
+							"TARGET" "follow_origin"		
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bane/bane_sap.vpcf"
+			"particle"  "particles/custom/shinobu/shinobu_skill_1.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bane.vsndevts"
+		}
+	}
+
+	"bvo_shinobu_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRange"						"1100"
+		"AbilityCastPoint"						"0.3"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"110 130 150 170 190"
+		"AbilityCooldown"						"22.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"150 200 250 300 450"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"0.75 1.0 1.25 1.5 1.75"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_2_throw"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_2"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Juggernaut.Attack"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"OnProjectileFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_2_throw_back"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_shinobu_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"  "particles/units/heroes/hero_axe/axe_culling_blade_kill.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_juggernaut.vsndevts"
+		}
+	}
+
+	"bvo_shinobu_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_BOTH"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"150"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"40.0"
+		"AbilityManaCost"				"225"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"15 17 20 22 25"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"percent_swap"					"20 25 30 35 40"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_3"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Bloodseeker.Rupture"
+				"Target"		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_shinobu_skill_3_buff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"EffectName"		"particles/custom/shinobu/shinobu_skill_3_alt.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_3_gain"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_3_lose"
+					}
+				}
+			}
+
+			"bvo_shinobu_skill_3_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"EffectName"		"particles/units/heroes/hero_bloodseeker/bloodseeker_rupture.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_3_lose"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_3_gain"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bane/bane_sap.vpcf"
+			"particle"  "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+			"particle"  "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture.vpcf"
+		}
+	}
+
+	"bvo_shinobu_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_CHANNELLED"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_4"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AbilityCooldown"						"70"
+		"AbilityManaCost"						"350"
+		"AbilityChannelTime"					"4.0"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"0.5 0.75 1.0 1.25 1.5"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"800 800 800 800 800"
+			}
+		}
+
+		"OnAbilityPhaseStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_4_sound"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_shinobu_skill_4_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_4_stop_force"
+			}
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_shinobu_skill_4_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnChannelFinish"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_4_stop_sfx"
+			}
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_shinobu_skill_4_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_shinobu_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_NONE"
+
+				"Aura"          	"bvo_shinobu_skill_4_effect_modifier"
+				"Aura_Radius"   	"%radius"
+				"Aura_Teams"    	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"    	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"    	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+			}
+
+			"bvo_shinobu_skill_4_effect_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"ThinkInterval"  "0.5"
+				"OnIntervalThink"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_shinobu_skill_4_debuff_modifier"
+						"Target"
+			            {
+			                "Center" "TARGET"
+			                "Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+			            }
+						"Duration"		"2.1"
+					}
+				}
+			}
+
+			"bvo_shinobu_skill_4_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-10"
+				    "MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "-10"
+				}
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_4_damage"
+					}
+				}
+			}
+
+			"bvo_shinobu_skill_4_sound_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_4_stop"
+					}
+				}
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_4_stop_force"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"	"particles/custom/shinobu/shinobu_scream_owner.vpcf"
+		}
+	}
+
+	"bvo_shinobu_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags" 				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_shinobu_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"450"
+		"AbilityCooldown"						"135.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"1000"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"agi_multi"						"1 2 3 4 5"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"stack_creep"					"1 2 3 4 5"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"stack_hero"					"1 2 3 4 5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_shinobu.lua"
+				"Function"		"bvo_shinobu_skill_5"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_life_stealer/life_stealer_infest_emerge_bloody.vpcf"
+				"EffectAttachType"  "attach_hitloc"
+				"Target"
+				{
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_LifeStealer.consume"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_shinobu_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_shinobu_skill_5_effect_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"EffectName"		"particles/econ/events/fall_major_2015/teleport_start_fallmjr_2015_lvl2_black_b.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_shinobu.lua"
+						"Function"		"bvo_shinobu_skill_5_end"
+					}
+				}
+			}
+
+			"bvo_shinobu_skill_5_bonus_modifier"
+			{
+				"IsBuff"	"1"
+				"IsHidden"	"0"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE | MODIFIER_ATTRIBUTE_PERMANENT"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_STATS_STRENGTH_BONUS"	"1"
+					"MODIFIER_PROPERTY_STATS_AGILITY_BONUS"		"1"
+					"MODIFIER_PROPERTY_STATS_INTELLECT_BONUS"	"1"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_life_stealer/life_stealer_infest_emerge_bloody.vpcf"
+			"particle"  "particles/econ/events/fall_major_2015/teleport_start_fallmjr_2015_lvl2_black_b.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_queenofpain.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_life_stealer.vsndevts"
+		}
+	}
+
+	//Kuma
+	"bvo_kuma_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_rukia.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_antimage.vsndevts"
+		}
+	}
+
+	"bvo_kuma_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"8.0"
+		"AbilityCastRange"						"1000"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"int_multi"						"1.0 1.25 1.5 1.75 2.0 2.25"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Phoenix.SunRay.Cast"
+				"Target"			"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kuma.lua"
+				"Function"		"bvo_kuma_skill_1"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kuma.lua"
+				"Function"		"bvo_kuma_skill_1_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/kuma/bvo_kuma_skill_1_gale.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phoenix.vsndevts"
+		}
+	}
+
+	"bvo_kuma_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"armor_bonus"					"7 9 11 13 15"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kuma_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+		
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"	"%armor_bonus"
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_2"
+						"damage"		"%attack_damage"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_kuma_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"1000"
+		"AbilityCastAnimation"			"ACT_DOTA_CHANNEL_ABILITY_1"
+		"AbilityCooldown"				"30.0"
+		"AbilityManaCost"				"350"
+		"AbilityChannelTime"			"8.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 250 300 350 400"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"4.0 4.5 5.0 5.5 6.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_kuma_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"8.0"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_kuma_skill_3_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kuma_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_3_cast"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Lina.attack"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kuma.lua"
+				"Function"		"bvo_kuma_skill_3_damage"
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/hero_kuma/kumaball.vmdl"
+		}
+	}
+
+	"bvo_kuma_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_4"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"800"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AbilityCooldown"						"80.0 75.0 70.0 65.0 60.0"
+		"AbilityManaCost"						"500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_heal"			"1.5"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_mana"			"0.75"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"10.0"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"radius"			"400"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"reflect"			"40 50 60 70 80"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_kuma_skill_4_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_kuma.lua"
+				"Function"		"bvo_kuma_skill_4_init"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kuma_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/items_fx/bottle.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_4_heal"
+					}
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_4_damage"
+						"damage"		"%attack_damage"
+					}
+				}
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Dark_Seer.Ion_Shield_Start"
+						"Target" 		"TARGET"
+					}
+					"AttachEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_dark_seer/dark_seer_ion_shell.vpcf"
+						"EffectAttachType"  "attach_head"
+						"Target"            "TARGET"
+
+						"ControlPoints"
+						{
+							"01"	"400 400 400"
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items_fx/bottle.vpcf"
+			"particle"  "particles/units/heroes/hero_dark_seer/dark_seer_ion_shell.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_dark_seer.vsndevts"
+		}
+	}
+
+	"bvo_kuma_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_kuma_skill_5"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"						"140.0"
+		"AbilityManaCost"						"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"int_multi"			"14 18 22 26 30"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"radius"			"900"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_kuma_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"3.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_CAST_ABILITY_1"
+			}
+			"DelayedAction"
+			{
+				"Delay"     "3.0"
+				"Action"    
+				{
+					"AttachEffect"
+					{
+						"EffectName"        "particles/base_destruction_fx/gensmoke.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "CASTER"
+					}
+					"FireEffect"
+					{
+						"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+						"EffectAttachType" 	"follow_origin"
+						"EffectRadius"		"%radius"
+						"Target" 			"CASTER"
+						"ControlPoints"
+						{
+							"01"	"%radius 0 %radius"
+						}
+					}
+
+					"FireSound"
+					{
+						"EffectName"		"Hero_Centaur.HoofStomp"
+						"Target" 			"CASTER"
+					}
+					"ActOnTargets"
+					{
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Radius" 	"%radius"
+							"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+							"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+						}
+					
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_kuma.lua"
+								"Function"		"bvo_kuma_skill_5_damage"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kuma_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_5_dummy"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_kuma.lua"
+						"Function"		"bvo_kuma_skill_5_dead"
+					}
+				}
+			}
+
+			"bvo_kuma_skill_5_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-50" 
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/hero_kuma/kumaball.vmdl"
+			"particle"  "particles/base_destruction_fx/gensmoke.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+		}
+	}
+
+	//Brook
+	"bvo_brook_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_brook_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"8.0"
+		"AbilityManaCost"				"30"
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_brook_skill_0_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"4.0"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Dark_Seer.Surge"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_brook_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"EffectName"		"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+				"EffectAttachType"	"follow_hitloc"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "25"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "650"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"			"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_dark_seer.vsndevts"
+		}
+	}
+
+	"bvo_brook_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_brook_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"14.0 13.0 12.0 11.0 10.0 9.0"
+		"AbilityCastRange"						"900"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"250"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"hp_damage"						"12"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_DeathProphet.Silence"
+				"Target"			"CASTER"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/econ/items/vengeful/vengeful_weapon_talon/vengeful_wave_of_terror_weapon_talon.vpcf"
+				"MoveSpeed"		 "1000"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "900"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "300"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_brook_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_sleep.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+	            {
+		            "MODIFIER_STATE_STUNNED"        		"MODIFIER_STATE_VALUE_ENABLED"
+		            "MODIFIER_STATE_LOW_ATTACK_PRIORITY"	"MODIFIER_STATE_VALUE_ENABLED"
+	            }
+
+	            "OnTakeDamage"
+	            {
+	            	"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_brook.lua"
+						"Function"		"bvo_brook_skill_1_end"
+					}
+	            }
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_brook.lua"
+				"Function"		"bvo_brook_skill_1_damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_brook_skill_1_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"3.0"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_sleep.vpcf"
+			"particle"  "particles/econ/items/vengeful/vengeful_weapon_talon/vengeful_wave_of_terror_weapon_talon.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+	}
+
+	"bvo_brook_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_brook_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"22.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"2.0 3.0 4.0 5.0 6.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_brook.lua"
+				"Function"		"bvo_brook_skill_2"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_brook.lua"
+			    "HorizontalControlFunction" "bvo_brook_skill_2_dash"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Particle"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_brook.lua"
+				"Function"		"bvo_brook_skill_2_damage"
+				"multi"			"%agi_multi"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Magnataur.ShockWave.Target"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_brook_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_brook_skill_3"
+		
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCooldown"				"85 80 75 70 65"
+		"AbilityManaCost"				"300"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"reincarnate_time"		"3.0"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_skeletonking.vsndevts"
+			"particle"	"particles/units/heroes/hero_skeletonking/wraith_king_reincarnate.vpcf"
+			"particle"	"particles/units/heroes/hero_skeletonking/skeleton_king_death.vpcf"
+		}
+
+		"Modifiers"
+		{
+			"bvo_brook_skill_3_reincarnation_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"heroes/ability_brook.lua"
+						"Function"			"bvo_brook_skill_3"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_brook_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_brook_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"80"
+		"AbilityCastRange"						"700"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"400"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"delay"				"1.0"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"agi_multi"			"2 3 4 5 6"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"800 1000 1200 1400 1600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/brook/ability_brook_4.lua"
+				"Function"		"bvo_brook_skill_4"
+				"Target"		"POINT"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_brook_skill_4_caster"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"1"
+		
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/brook/ability_brook_4.lua"
+						"Function"		"bvo_brook_skill_4_cast"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	"bvo_brook_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"			"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"			"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_brook_skill_5"
+		
+		"AbilityType"					"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"						"5"
+		"RequiredLevel"					"20"
+		"LevelsBetweenUpgrades"			"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"500"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"110"
+		"AbilityManaCost"				"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"hero_multi"		"35 70 105 140 175"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"1000"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"0.8"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"delay"				"0.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/brook/ability_brook_5.lua"
+				"Function"		"bvo_brook_skill_5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_brook_skill_5_modifier_slide"
+				"Target" 		"CASTER"
+				"Duration"		"%delay"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_brook_skill_5_modifier_caster"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_brook_skill_5_modifier_enemy"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_brook_skill_5_modifier_slide"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/brook/ability_brook_5.lua"
+						"Function"		"bvo_brook_skill_5_end"
+					}
+				}
+			}
+
+			"bvo_brook_skill_5_modifier_caster"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_brook_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"FireEffect"
+					{
+						"EffectName"        "particles/units/heroes/hero_ancient_apparition/ancient_apparition_ice_blast_death.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+					}
+					"FireEffect"
+					{
+						"EffectName"        "particles/econ/items/ancient_apparition/aa_blast_ti_5/ancient_apparition_ice_blast_explode_ti5.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"            "TARGET"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Ancient_Apparition.IceBlast.Target"
+						"Target" 		"TARGET"
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/brook/ability_brook_5.lua"
+						"Function"		"bvo_brook_skill_5_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_ancient_apparition.vsndevts"
+			"particle"  "particles/econ/items/templar_assassin/templar_assassin_focal/templar_assassin_meld_focal.vpcf"
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_ice_blast_death.vpcf"
+			"particle"  "particles/econ/items/ancient_apparition/aa_blast_ti_5/ancient_apparition_ice_blast_explode_ti5.vpcf"
+		}
+	}
+
+	//Robin
+	"bvo_robin_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_robin_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+
+		"AbilityCooldown"				"10.0"
+		"AbilityManaCost"				"50"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"range"				"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_robin.lua"
+				"Function"		"Leap"
+				"Target"		"POINT"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_robin.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			    "VerticalControlFunction" 	"LeapVertical"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Rubick.Telekinesis.Cast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_robin_skill_0_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"0.5"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_robin_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+			
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_robin_skill_0_af_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"OnAttackLanded"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_robin_skill_0_enemy_modifier"
+						"Target"		"TARGET"
+						"Duration"		"0.5"
+					}
+				}
+			}
+
+			"bvo_robin_skill_0_enemy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+			
+				"EffectName"		"particles/units/heroes/hero_bane/bane_fiendsgrip_hands.vpcf"
+				"EffectAttachType"	"attach_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_rubick.vsndevts"
+			"particle"  "particles/units/heroes/hero_bane/bane_fiendsgrip_hands.vpcf"
+		}
+	}
+
+	"bvo_robin_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_robin_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"265"
+		"AbilityCooldown"						"14.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"275"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_robin.lua"
+						"Function"		"bvo_robin_skill_1_damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_robin_skill_1_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.5"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"			"Hero_NagaSiren.Ensnare.Cast"
+				"Target"				"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_keeper_of_the_light/keeper_of_the_light_blinding_light_aoe.vpcf"
+				"EffectAttachType"  "start_at_customorigin"
+				"TargetPoint"		"POINT"
+
+				"ControlPoints"
+				{
+					"01"	"POINT"
+					"02"	"%radius 0 0"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_robin_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_ROOTED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"EffectName"			"particles/units/heroes/hero_siren/siren_net.vpcf"
+				"EffectAttachType"		"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"					"soundevents/game_sounds_heroes/game_sounds_naga_siren.vsndevts"
+			"particle" 					"particles/units/heroes/hero_keeper_of_the_light/keeper_of_the_light_blinding_light_aoe.vpcf"
+			"particle"					"particles/units/heroes/hero_siren/siren_net.vpcf"
+		}
+	}
+
+	"bvo_robin_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_robin_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"25.0 23.0 21.0 19.0 17.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration"						"2.0 2.25 2.5 2.75 3.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_robin_skill_2_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"			"Hero_ShadowShaman.Shackles.Cast"
+				"Target"				"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_robin_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_ROOTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"	"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"StatusEffectName" 		"particles/status_fx/status_effect_shaman_shackle.vpcf" 	   
+				"StatusEffectPriority"  "10"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"150"//600 / 4
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"					"soundevents/game_sounds_heroes/game_sounds_shadowshaman.vsndevts"
+			"particle"  				"particles/status_fx/status_effect_shaman_shackle.vpcf"
+		}
+	}
+
+	"bvo_robin_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_robin_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"4.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_1"			"400"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_2"			"500"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_3"			"700"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_robin.lua"
+				"Function"		"bvo_robin_skill_3"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DoomBringer.LvlDeath"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_doombringer.vsndevts"
+			"particle"			"particles/units/heroes/hero_doom_bringer/doom_bringer_lvl_death.vpcf"
+		}
+	}
+
+	"bvo_robin_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_robin_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"60.0"
+		"AbilityCastRange"						"800"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"1000 1250 1500 1750 2000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_robin_skill_4_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"4.0"
+			}
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Batrider.FlamingLasso.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_robin_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_ROOTED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"EffectName"			"particles/units/heroes/hero_shadowshaman/shadowshaman_shackle_net.vpcf"
+						"EffectAttachType"		"follow_origin"
+						"Target"				"TARGET"
+						"ControlPointEntities"
+						{
+							"TARGET"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+							"TARGET"	"attach_hitloc"
+						}
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"					"soundevents/game_sounds_heroes/game_sounds_batrider.vsndevts"
+			"particle"  				"particles/units/heroes/hero_shadowshaman/shadowshaman_shackle.vpcf"
+		}
+	}
+
+	"bvo_robin_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_robin_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AOERadius"								"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"130.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"int_multi"						"8 9 10 11 12"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"6 6 7 7 8"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_robin_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_robin_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_robin.lua"
+						"Function"		"bvo_robin_skill_5"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Bane.Enfeeble.Cast"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_robin_skill_5_dummy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"EffectName"		"particles/units/heroes/hero_bane/bane_fiendsgrip_hands.vpcf"
+				"EffectAttachType"	"attach_origin"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_robin.lua"
+						"Function"		"bvo_robin_skill_5_dummy"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bane/bane_fiends_grip.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bane.vsndevts"
+		}
+	}
+
+	//Ikkaku
+	"bvo_ikkaku_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"20"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE"	"%damage" 
+				}
+			}
+		}
+	}
+
+	"bvo_ikkaku_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastRange"				"600"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"				"12.5"
+		"AbilityManaCost"				"150"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"100 200 300 400 500 600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/ability_ikkaku.lua"
+				"Function"					"bvo_ikkaku_skill_1"
+				"damage"					"%damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ikkaku_skill_1_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"0.75"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_1_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_lancer.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_ikkaku_skill_2"
+	{
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_axe.vsndevts"
+			"particle"			"particles/units/heroes/hero_axe/axe_attack_blur_counterhelix.vpcf"
+		}
+
+		"AbilityCooldown"				"0.3"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"trigger_chance"			"9 12 15 18 21"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"cooldown"					"0.5"
+			}
+			// Extra
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"trigger_radius"			"2000"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"radius1"					"320"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"damage1"					"1.0 1.25 1.5 1.75 2.0"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"radius2"					"410"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"damage2"					"2.0 2.25 2.5 2.75 3.0"
+			}
+			"08"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"175"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_2_aura"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+		
+				"Aura" 			"bvo_ikkaku_skill_2_modifier"
+				"Aura_Radius" 	"%trigger_radius"
+				"Aura_Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_MECHANICAL"
+			}
+
+			"bvo_ikkaku_skill_2_modifier"
+			{
+				"IsHidden"			"1"
+
+				"OnAttackStart"
+				{
+					"Random"
+					{
+						"Chance"			"%trigger_chance"
+						"PseudoRandom" 		"DOTA_PSEUDO_RANDOM_JUGG_CRIT"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_ikkaku.lua"
+								"Function"		"bvo_ikkaku_skill_2"
+								"helix_modifier"	"bvo_ikkaku_skill_2_self"
+							}
+						}
+					}
+				}
+			}
+
+			"bvo_ikkaku_skill_2_self"
+			{
+				"Duration"		"%cooldown"
+				"IsHidden"		"1"
+
+				"EffectName"	"particles/units/heroes/hero_axe/axe_attack_blur_counterhelix.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_Axe.CounterHelix"
+						"Target" 		"CASTER"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ikkaku.lua"
+						"Function"		"bvo_ikkaku_skill_2_damage"
+					}
+
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_2_rotate"
+						"Target" 		"CASTER"
+						"Duration"		"0.15"
+					}
+				}
+			}
+
+			"bvo_ikkaku_skill_2_rotate"
+			{
+				"IsHidden"	"1"
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 72 0"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_ikkaku_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"150 225 300 375 450"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_ms"						"-20 -15 -10 -5 0"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_as"						"-25 -18 -12 -6 0"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_3_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE" "%bonus_basedamage"
+					"MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%bonus_ms"
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%bonus_as"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ikkaku.lua"
+						"Function"		"bvo_ikkaku_skill_3_end"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_4_modifier"
+						"Target" 		"CASTER"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_4_modifier_boni"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_ikkaku_skill_3_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-20" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ikkaku.lua"
+				"Function"		"bvo_ikkaku_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ikkaku_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_TrollWarlord.BattleTrance.Cast"
+				"Target" 		"CASTER"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"200"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_3_slow_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"2.0"
+					}
+				}
+			}
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+				"EffectAttachType" 	"follow_origin"
+				"EffectRadius"		"600"
+				"Target" 			"CASTER"
+				"ControlPoints"
+				{
+					"01"	"600 0 600"
+				}
+			}
+
+			"FireSound"
+			{
+				"EffectName"		"Hero_Centaur.HoofStomp"
+				"Target" 			"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"model"	"models/hero_ikkaku/hero_ikkaku_base.vmdl"
+			"model" "models/hero_ikkaku/hero_ikkaku_bankai_base.vmdl"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_troll_warlord.vsndevts"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"particle"	"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+		}
+	}
+
+	"bvo_ikkaku_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCastPoint"						"0.1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"100 90 80 70 60"
+
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Duration" "45.0"
+				"ThinkInterval"  "2.5"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ikkaku.lua"
+						"Function"		"bvo_ikkaku_skill_4_stack"
+					}
+				}
+
+				"EffectName"		"particles/items_fx/aura_assault.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_4_modifier"
+						"Target" 		"CASTER"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_ikkaku_skill_4_modifier_boni"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"Target"					"CASTER"
+						"EffectName"				"particles/units/heroes/hero_ursa/ursa_enrage_buff.vpcf"
+						"EffectAttachType"			"start_at_customorigin"
+						"ControlPointEntities"
+						{
+							"CASTER"				"attach_attack1"
+						}
+					}
+					
+					"AttachEffect"
+					{
+						"Target"					"CASTER"
+						"EffectName"				"particles/units/heroes/hero_ursa/ursa_enrage_buff.vpcf"
+						"EffectAttachType"			"start_at_customorigin"
+						"ControlPointEntities"
+						{
+							"CASTER"				"attach_attack2"
+						}
+					}
+				}
+			}
+
+			"bvo_ikkaku_skill_4_modifier_boni"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "60"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"Target" "CASTER"
+				"ModifierName" "bvo_ikkaku_skill_4_modifier"
+			}
+			"ApplyModifier"
+			{
+				"Target" "CASTER"
+				"ModifierName" "bvo_ikkaku_skill_4_modifier_boni"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ikkaku.lua"
+				"Function"		"bvo_ikkaku_skill_4"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_EmberSpirit.FlameGuard.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/items_fx/aura_assault.vpcf"
+			"particle"	"particles/units/heroes/hero_ursa/ursa_enrage_buff.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ember_spirit.vsndevts"
+		}
+	}
+
+	"bvo_ikkaku_skill_4_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"100 90 80 70 60"
+	}
+
+	"bvo_ikkaku_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"0.25"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"150.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"charge_multi"					"6 7 8 9 10"
+			}
+
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"14 17 20 23 26"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ikkaku.lua"
+				"Function"		"bvo_ikkaku_skill_5"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"CASTER"
+			    "ScriptFile"    "heroes/ability_ikkaku.lua"
+			    "HorizontalControlFunction" "LeapHorizonal"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ikkaku_skill_5_modifier"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ikkaku.lua"
+				"Function"		"bvo_ikkaku_skill_5_hpcheck"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ikkaku_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"ThinkInterval"  "0.3"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_ikkaku.lua"
+						"Function"		"bvo_ikkaku_skill_5_tick"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ikkaku.lua"
+				"Function"		"bvo_ikkaku_skill_5_damage"
+				"multi1"			"%charge_multi"
+				"multi2"		"%str_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+		}
+	}
+
+	"bvo_ikkaku_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_ikkaku_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"0.25"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"150.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"charge_multi"					"6 7 8 9 10"
+			}
+
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"14 17 20 23 26"
+			}
+		}
+	}
+
+	//Tousen
+	"bvo_tousen_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_tousen.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_tousen_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AOERadius"								"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"22 20 18 16 14 12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_hero"					"300 350 400 450 500 550"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_DeathProphet.Silence"
+				"Target"			"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"600"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_tousen.lua"
+						"Function"		"bvo_tousen_skill_1_damage_non"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_tousen_skill_1_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"1.75"
+					}
+				}
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_death_prophet/death_prophet_silence.vpcf"
+				"EffectAttachType"  "start_at_customorigin"
+				"Target"       		"CASTER"
+				"ControlPoints"
+				{
+					"01"	"700 0 0"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_tousen_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_sleep.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+	            {
+		            "MODIFIER_STATE_STUNNED"        		"MODIFIER_STATE_VALUE_ENABLED"
+		            "MODIFIER_STATE_LOW_ATTACK_PRIORITY"	"MODIFIER_STATE_VALUE_ENABLED"
+	            }
+
+	            "Properties"
+	            {
+	            	"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "-10"
+	            }
+
+	            "OnTakeDamage"
+	            {
+	            	"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_tousen.lua"
+						"Function"		"bvo_tousen_skill_1_damage_hero"
+						"damage"		"%damage_hero"
+					}
+	            }	
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_sleep.vpcf"
+			"particle" 	"particles/units/heroes/hero_death_prophet/death_prophet_silence.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_death_prophet.vsndevts"
+		}
+	}
+
+	"bvo_tousen_skill_1_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AOERadius"								"600"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"22 20 18 16 14 12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_hero"					"300 350 400 450 500 550"
+			}
+		}
+	}
+
+	"bvo_tousen_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"evasion"			"13 16 19 22 25"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"crit_chance"		"10 12.5 15 17.5 20"
+			}
+		}
+
+		"Modifiers"
+		{
+			"item_evasion_unique"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes" "MODIFIER_ATTRIBUTE_NONE"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_EVASION_CONSTANT" "%evasion"
+				}
+			}
+
+			"bvo_tousen_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+			
+				"OnAttackLanded"
+				{
+					"RemoveModifier"
+			        {
+			            "ModifierName" "bvo_tousen_skill_2_modifier_crit_modifier"
+			            "Target" "CASTER"
+			        }
+			        "Random"
+			        {
+			            "Chance" "%crit_chance"
+			            "OnSuccess"
+			            {
+			                "ApplyModifier"
+			                {
+			                    "ModifierName" "bvo_tousen_skill_2_modifier_crit_modifier"
+			                    "Target"    "CASTER"    
+			                }        
+			            }
+			            "OnFailure"
+						{
+						}
+			        }
+				}
+			}
+
+			"bvo_tousen_skill_2_modifier_crit_modifier"
+			{
+			    "IsHidden"  "1"
+			    "Properties"
+			    {
+			        "MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE" "200"
+			    }
+
+			    "OnAttackLanded"
+			    {
+			        "RemoveModifier"
+			        {
+			            "ModifierName"  "bvo_tousen_skill_2_modifier_crit_modifier"
+			            "Target"    "CASTER"
+			        }
+
+			        // Basic blood particle effect
+			        "FireEffect"
+			        {
+			        	"EffectName" "particles/units/heroes/hero_phantom_assassin/phantom_assassin_crit_impact.vpcf"
+			            "EffectAttachType"  "follow_origin"
+			            "Target"    "TARGET"
+			        }
+			    }
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phantom_assassin/phantom_assassin_crit_impact.vpcf"
+		}
+	}
+
+	"bvo_tousen_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_AOE | DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AOERadius"								"275"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+		
+		"AbilityCastRange"				"700"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityManaCost"						"280"
+		"AbilityCooldown"						"30"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"hp_damage"			"3.0 3.5 4.0 4.5 5.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"TrackingProjectile"
+			{
+				"Target"           	"TARGET"
+				"EffectName"		"particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_arcane_orb.vpcf"
+				"Dodgeable"			"1"
+				"ProvidesVision"	"1"
+				"VisionRadius"		"250"
+				"MoveSpeed"        	"1200"
+				"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ObsidianDestroyer.ArcaneOrb"
+				"Target"		"TARGET"	
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"275"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"		"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
+				}
+			
+				"Action"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_tousen_skill_3_burn"
+						"Target" 		"TARGET"
+						"Duration"		"7.0"
+					}
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_WitchDoctor.Maledict_Cast"
+				"Target" 		"TARGET"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_tousen_skill_3_burn"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_oracle/oracle_purifyingflames_hit.vpcf"
+				"EffectAttachType"	"follow_origin"
+				
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_tousen_skill_3_burn_e"
+						"Target" 		"TARGET"
+						"Duration"		"7.0"
+					}
+				}
+
+				"ThinkInterval"  "0.7"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_tousen.lua"
+						"Function"		"bvo_tousen_skill_3_damage"
+						"multi"			"%hp_damage"
+					}
+				}
+			}
+
+			"bvo_tousen_skill_3_burn_e"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_oracle/oracle_fortune_purge_root_ribbon.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_arcane_orb.vpcf"
+			"particle"  "particles/units/heroes/hero_oracle/oracle_purifyingflames_hit.vpcf"
+			"particle"  "particles/units/heroes/hero_oracle/oracle_fortune_purge_root_ribbon.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_obsidian_destroyer.vsndevts"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_witchdoctor.vsndevts"
+		}
+	}
+
+	"bvo_tousen_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AnimationPlaybackRate" "0.6"
+
+		"AbilityCastPoint"				"0.85"
+		"AbilityCastRange"				"1400"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"70"
+		"AbilityManaCost"				"350"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"2 2.5 3 3.5 4"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_tousen.lua"
+				"Function"		"bvo_tousen_skill_4"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_PhantomAssassin.Dagger.Cast"
+				"Target"			"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_tousen.lua"
+				"Function"		"bvo_tousen_skill_4_damage"
+				"multi"			"%agi_multi"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_phantom_assassin/phantom_assassin_stifling_dagger.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts"
+			"model" "models/items/abaddon/weta_fractured_sword_of_eternity_weapon/weta_fractured_sword_of_eternity_weapon.vmdl"
+		}
+	}
+
+	"bvo_tousen_skill_4_off"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AnimationPlaybackRate" "0.6"
+
+		"AbilityCastPoint"				"0.85"
+		"AbilityCastRange"				"1200"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"				"70"
+		"AbilityManaCost"				"350"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"2 2.5 3 3.5 4"
+			}
+		}
+	}
+
+	"bvo_tousen_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"				"ability_datadriven"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_tousen_skill_5"
+		"AOERadius"							"900"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"150"
+		"AbilityManaCost"				"550"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"miss_chance"		"35 45 55 65 75"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_tousen.lua"
+				"Function"		"bvo_tousen_skill_5"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_FacelessVoid.Chronosphere"
+				"Target"			"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_tousen_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"20.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_tousen_skill_5_dummy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+
+				"Aura"        "bvo_tousen_skill_5_aura"
+				"Aura_Radius" "900"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_ATTACK_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_MAGIC_IMMUNE" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_SELECT" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_TEAM_MOVE_TO" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_tousen.lua"
+						"Function"		"bvo_tousen_skill_5_checkDistance"
+						"radius"		"900"
+					}
+				}
+			}
+
+			"bvo_tousen_skill_5_aura"
+			{
+				"Passive"			"0"
+				"IsDebuff" "1"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MISS_PERCENTAGE" "%miss_chance"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-30"
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_tousen_skill_5_dummy_self"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"0"
+
+				"Aura"        "bvo_tousen_skill_5_aura_self"
+				"Aura_Radius" "900"
+				"Aura_Teams"  "DOTA_UNIT_TARGET_TEAM_BOTH"
+				"Aura_Types"  "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"  "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+			}
+
+			"bvo_tousen_skill_5_aura_self"
+			{
+				"Passive"			"0"
+				"IsHidden" "1"
+
+				"States"
+				{
+					"MODIFIER_STATE_NOT_ON_MINIMAP" "MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_tousen_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_tousen.lua"
+						"Function"		"bvo_tousen_skill_5_end"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_FacelessVoid.TimeWalk"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/tousen/tousen_skill_5.vpcf"
+			"particle" "particles/custom/tousen/tousen_skill_5_enemy.vpcf"
+		}
+	}
+
+	//Renji
+	"bvo_renji_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_renji_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"7.0"
+		//"AbilityCastRange"					"650"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_renji_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"800"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"1.5 2.0 2.5 3.0 3.5 4.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Invoker.DeafeningBlast"
+				"Target" 		"CASTER"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_invoker/invoker_deafening_blast.vpcf"
+				"MoveSpeed"		 "1000"
+				"StartRadius"	 "125"//75
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "225"//325
+				"HasFrontalCone" "0"
+				"FixedDistance"  "800"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "200"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_1_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_invoker/invoker_deafening_blast.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_renji_skill_1_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"800"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"2.5 3 3.5 4 4.5 5"
+			}
+		}
+	}
+
+	"bvo_renji_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_renji_skill_2"
+		"AOERadius"								"300"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityChannelTime"					"0.9"
+
+		"AbilityCastRange"						"900"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"0.5"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175"
+		"AbilityCooldown"						"15"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"600 750 900 1050 1200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"20 20 20 20 20"
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_2"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ObsidianDestroyer.SanityEclipse.Cast"
+				"Target"		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_2_hit"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"300"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_renji.lua"
+						"Function"		"bvo_renji_skill_2_damage"
+						"damage"		"%damage"
+					}
+				}
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"300"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_renji.lua"
+						"Function"		"bvo_renji_skill_2_damage_self"
+						"damage"		"%damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_sanity_eclipse_area.vpcf"
+			"particle"  "particles/units/heroes/hero_obsidian_destroyer/obsidian_destroyer_arcane_orb.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_obsidian_destroyer.vsndevts"
+		}
+	}
+
+	"bvo_renji_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"30"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"6 7 8 9 10"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"20 22 24 26 28"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_3"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_renji_skill_3_disarm"
+				"Target" 		"CASTER"
+				"Duration"		"2.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_renji_skill_3_disarm"
+			{
+				"IsHidden"	"0"
+				"IsDebuff"	"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_renji.lua"
+						"Function"		"bvo_renji_skill_3_end"
+					}
+				}
+			}
+
+			"bvo_renji_skill_3_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_3_damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_renji_skill_3_stun"
+				"Target" 		"TARGET"
+				"Duration"		"0.1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/renji/renji_weapon_throw.vpcf"
+			"particle"  "particles/units/heroes/hero_lina/lina_spell_light_strike_array.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_renji_skill_3_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"30"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"6 7 8 9 10"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"20 22 24 26 28"
+			}
+		}
+	}
+
+	"bvo_renji_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_4"
+		"AOERadius"								"1300"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"75"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"8 9 10 11 12"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"30 35 40 45 50"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_4"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Lycan.SummonWolves"
+				"Target"		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_renji_skill_4_rotate"
+			{
+				"IsHidden"	"1"
+
+				"ThinkInterval"  "0.025"
+				"OnIntervalThink"
+				{
+					"Rotate"
+					{
+						"Target"	"CASTER"
+						"PitchYawRoll"	"0 18 0"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_renji.lua"
+						"Function"		"bvo_renji_skill_4_point_damage"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_renji.lua"
+						"Function"		"bvo_renji_skill_4_end"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_renji_skill_4_disarm"
+						"Target" 		"CASTER"
+						"Duration"		"6.0"
+					}
+				}
+			}
+
+			"bvo_renji_skill_4_disarm"
+			{
+				"IsHidden"	"0"
+				"IsDebuff"	"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"model"	"models/hero_renji/renji_bankai_part.vmdl"
+			"model"	"models/hero_renji/renji_bankai_head.vmdl"
+			"particle"  "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn.vpcf"
+		}
+	}
+
+	"bvo_renji_skill_4_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_4"
+		"AOERadius"								"1300"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"75"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"str_multi"						"8 9 10 11 12"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"lvl_multi"						"30 35 40 45 50"
+			}
+		}
+	}
+
+	"bvo_renji_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"120"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"drag_str_multi"				"7.5 7.5 7.5 7.5 7.5"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"final_str_mutli"				"16 22 28 34 40"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_5"
+			}
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_renji_skill_4_disarm"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_renji_skill_5_enemy_modifier"
+				"Target" 		"TARGET"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_renji_skill_5_self_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_renji_skill_5_enemy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 				"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_renji_skill_5_self_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_renji.lua"
+				"Function"		"bvo_renji_skill_5_prodmg"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn.vpcf"
+			"particle" "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+		}
+	}
+
+	"bvo_renji_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_renji_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"600"
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"120"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"drag_str_multi"				"7.5 7.5 7.5 7.5 7.5"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"final_str_mutli"				"16 22 28 34 40"
+			}
+		}
+	}
+
+	//Sado
+	"bvo_sado_skill_0" 
+	{
+		"BaseClass" 					"ability_datadriven"
+
+		"MaxLevel" 						"1"
+		"AbilityBehavior" 				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"				"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_sado_skill_0"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"chance"			"12"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"150"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"1.0"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"bvo_sado_skill_0_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"%chance"
+						"PseudoRandom" 		"DOTA_PSEUDO_RANDOM_JUGG_CRIT"
+						"OnSuccess"
+						{
+							"ApplyModifier"
+							{
+								"ModifierName"	"bvo_sado_skill_0_stun_modifier"
+								"Target"
+								{
+									"Center"  	"TARGET"
+									"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+								}
+								"Duration"		"%duration"
+							}
+							"Damage"
+							{
+								"Target"		"TARGET"
+								"Type"			"DAMAGE_TYPE_PHYSICAL"
+								"Damage"		"%damage"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			"bvo_sado_skill_0_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"	
+				"Attributes" 		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_sado_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_sado_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_NO"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"0.7"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75 100 125 150 175 200"
+		"AbilityCooldown"						"10.0"
+		"AbilityCastRange"						"1250"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 340 455 570 685 800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_invoker/invoker_deafening_blast.vpcf"
+				"MoveSpeed" "1200"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "1250"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_NONE"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Invoker.DeafeningBlast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"Damage"
+			{
+				"Target" "TARGET"
+				"Type" "DAMAGE_TYPE_MAGICAL"
+				"Damage" "%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_sado_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_sado_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_block"					"80 135 190 245 300"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance"						"35 35 35 35 35"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sado_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"OnTakeDamage"
+				{
+					"Random"
+					{
+						"Chance"			"%chance"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/ability_sado.lua"
+								"Function"		"bvo_sado_skill_2"
+								"damage"		"%attack_damage"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_sado_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_sado_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"35.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 500 600 700 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"800 800 800 800 800"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"stun_duration"					"1.25 1.25 1.25 1.25 1.25"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Brewmaster.ThunderClap"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sado.lua"
+						"Function"		"bvo_sado_skill_3_damage"
+					}
+				}
+			}
+			"FireEffect"
+			{
+				"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+				"EffectAttachType" 	"follow_origin"
+				"Target" 			"CASTER"
+				"ControlPoints"
+				{
+					"01"	"1200 0 1200"
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sado.lua"
+				"Function"		"bvo_sado_skill_3"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sado_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_sado_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"	
+				"Attributes" 		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_brewmaster.vsndevts"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_sado_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AUTOCAST"
+		"AbilityTextureName"					"icons/bvo_sado_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20 30 40 50 60"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"bonus_basedamage"				"70"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"armor"							"5"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"health"						"400"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"hp_regen"						"15"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"bat"							"0.15"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration_autocast"				"20.1 30.1 40.1 50.1 60.1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sado_skill_4_modifier"
+			{
+				"Passive" "0"
+				"IsHidden" "0"
+				"IsBuff" "1"
+
+				"EffectName"		"particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE"  "%bonus_basedamage"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"	"%armor"
+					"MODIFIER_PROPERTY_HEALTH_BONUS"			"%health"
+					"MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT"	"%hp_regen"
+					"MODIFIER_PROPERTY_BASE_ATTACK_TIME_CONSTANT"	"1.4"
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sado.lua"
+						"Function"		"bvo_sado_skill_4_end"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sado.lua"
+				"Function"		"bvo_sado_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sado_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_autocast"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ChaosKnight.Phantasm"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_chaos_knight.vsndevts"
+			"particle"  "particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+		}
+	}
+
+	"bvo_sado_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sado_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"250"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"110.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"final_damage"					"16 22 28 34 40"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_sado_skill_5_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_sado.lua"
+						"Function"		"bvo_sado_skill_5_damage"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_sado_skill_5_stun2_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"1.5"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_sado_skill_5_stun_self_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_sado_skill_5_stun2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_sado_skill_5_stun_self_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FROZEN"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_sado.lua"
+				"Function"		"bvo_sado_skill_5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sado_skill_5_stun_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"1.5"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_sado_skill_5_stun_self_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"1.5"
+			}
+			"ApplyMotionController"
+			{
+			    "Target" 		"TARGET"
+			    "ScriptFile"    "heroes/ability_sado.lua"
+			    "HorizontalControlFunction" "KnockbackTarget"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/econ/items/brewmaster/brewmaster_offhand_elixir/brewmaster_thunder_clap_elixir.vpcf"
+		}
+	}
+
+	"bvo_sado_skill_5_off"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_sado_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"110.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"final_damage"					"16 22 28 34 40"
+			}
+		}
+	}
+
+	//Megumin
+	"bvo_megumin_skill_0" 
+	{
+		"BaseClass" 					"ability_datadriven"
+
+		"MaxLevel" 						"1"
+		"AbilityBehavior" 				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityUnitDamageType"			"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_0"
+
+		"AbilityCooldown"				"12.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"175"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"int_multi"			"1"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"275"
+			}
+		}
+
+		"Modifiers"
+		{ 
+			"bvo_megumin_skill_0_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_megumin.lua"
+						"Function"		"bvo_megumin_skill_0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/techies/techies_arcana/techies_suicide_arcana.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_megumin_skill_1" 
+	{
+		"BaseClass" 							"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_1"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"900"
+		"AbilityCastPoint"						"0.5"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"14.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 525 650 775 900 1025"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"275"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"particle_radius"				"375"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"TargetPoint"			"POINT"
+				"EffectName"			"particles/custom/megumin/megumin_skill_1_cowlofice.vpcf"
+				"EffectAttachType"		"world_origin"
+				"ControlPoints"
+				{
+					"01"				"%particle_radius %particle_radius %particle_radius"
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_megumin.lua"
+				"Function"		"bvo_megumin_skill_1"
+				"Target"		"POINT"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_megumin_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"EffectName"		"particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/megumin/megumin_skill_1_cowlofice.vpcf"
+			"particle"  "particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_gyrocopter.vsndevts"
+		}
+	}
+
+	"bvo_megumin_skill_2" 
+	{
+		"BaseClass" 							"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_2"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRangeBuffer"				"150"
+		"AbilityCastRange"						"900"
+		"AbilityCastPoint"						"2.0"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_4"
+		"AnimationPlaybackRate"					"0.6"
+		"AnimationIgnoresModelScale"			"1"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"225"
+		"AbilityCooldown"						"32.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"400 600 800 1000 1200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"int_multi"						"2.0 2.5 3.0 3.5 4.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"175"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_megumin.lua"
+				"Function"		"bvo_megumin_skill_3"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_megumin_skill_3_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_megumin.lua"
+				"Function"		"bvo_megumin_skill_3_hit"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/custom/megumin/skill_3_projectile/megumin_skill_3_projectile.vpcf"
+			"particle"  "particles/custom/megumin/skill_4/megumin_skill_4_area.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_obsidian_destroyer.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ember_spirit.vsndevts"
+		}
+	}
+
+	"bvo_megumin_skill_3" 
+	{
+		"BaseClass" 							"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_3"
+		"AOERadius"								"%target_radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"900"
+		"AbilityCastPoint"						"0.5"
+		"AbilityCastAnimation"					"ACT_DOTA_CHANNEL_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityChannelTime"					"4.0"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"60.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"325"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"int_multi"						"3.0 3.5 4.0 4.5 5.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"175"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"target_radius"					"425"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"blasts_tp"						"5 10 15 20 25"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"blasts"						"6 11 16 21 26"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/megumin/ability_megumin_3.lua"
+				"Function"		"bvo_megumin_skill_3"
+				"Target"		"POINT"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_megumin_skill_3_channel_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"4.0"
+			}
+		}
+
+		"OnChannelSucceeded"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_megumin_skill_3_channel_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_megumin_skill_3_channel_modifier"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_megumin_skill_3_channel_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/megumin/ability_megumin_3.lua"
+						"Function"		"bvo_megumin_skill_3_interval"
+					}
+				}
+			}
+
+			"bvo_megumin_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"EffectName"		"particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/invoker/invoker_apex/invoker_sun_strike_immortal1.vpcf"
+			"particle"  "particles/units/heroes/hero_sniper/sniper_headshot_slow.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_gyrocopter.vsndevts"
+		}
+	}
+
+	"bvo_megumin_skill_4" 
+	{
+		"BaseClass" 							"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"60.0 55.0 50.0 45.0 40.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"12"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_megumin_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_oracle/oracle_fatesedict.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_megumin_skill_4_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Invoker.Alacrity"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_techies/techies_remote_mines_detonate.vpcf"
+			"particle"  "particles/units/heroes/hero_oracle/oracle_fatesedict.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_puck.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_megumin_skill_5" 
+	{
+		"BaseClass" 							"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_CHANNELLED | DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_megumin_skill_5"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"1200"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CHANNEL_ABILITY_5"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400 300 200 100 0"
+		"AbilityCooldown"						"100.0 95.0 90.0 85.0 80.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"1200"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"channel_time"					"10.0 8.5 7.0 5.5 4.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"mana_multi"					"1.0 1.25 1.5 1.75 2.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_megumin_skill_5_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%channel_time"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_megumin.lua"
+				"Function"		"bvo_megumin_skill_5_start"
+				"Target"		"POINT"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_megumin.lua"
+				"Function"		"bvo_megumin_skill_5"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Luna.Eclipse.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_megumin_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"States"
+				{
+					"MODIFIER_STATE_DISARMED"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_megumin.lua"
+						"Function"		"bvo_megumin_skill_5_stop"
+					}
+				}
+
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ability_megumin.lua"
+						"Function"		"bvo_megumin_skill_5_order"
+					}
+				}
+			}
+
+			"bvo_megumin_skill_5_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/megumin/skill_5/megumin_skill_5_a.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_luna.vsndevts"
+		}
+	}
+
+	//Squall
+	"bvo_squall_skill_0"
+	{
+		"BaseClass" 					"ability_datadriven"
+
+		"MaxLevel" 						"1"
+		"AbilityBehavior" 				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_squall_skill_0"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_revolver"	"50"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"durability_revolver"	"20"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"chance_shear_trigger"	"20"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"multi_shear_trigger"	"240"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"durability_shear_trigger"	"30"
+			}
+			"06"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"chance_flame_saber"	"25"
+			}
+			"07"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage_flame_saber"	"100"
+			}
+			"08"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"agi_multi_flame_saber"	"3"
+			}
+			"09"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"durability_flame_saber"	"50"
+			}
+			"10"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"chance_punishment"		"20"
+			}
+			"11"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage_punishment"		"300"
+			}
+			"12"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"stun_punishment"		"1.25"
+			}
+			"13"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"durability_punishment"		"40"
+			}
+			"14"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_lionheart"	"400"
+			}
+			"15"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"durability_lionheart"	"70"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_squall_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_revolver_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			//Revolver
+			"bvo_squall_skill_0_revolver_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability"
+						"modifier"		"bvo_squall_skill_0_revolver_modifier"
+						"durability"	"%durability_revolver"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_revolver_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability_down"
+						"amount"		"1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_revolver_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_revolver_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%damage_revolver" 
+				}
+			}
+
+			//Shear Trigger
+			"bvo_squall_skill_0_shear_trigger_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"EffectName"		"particles/units/heroes/hero_magnataur/magnataur_empower.vpcf"
+				"EffectAttachType"	"attach_hitloc"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability"
+						"modifier"		"bvo_squall_skill_0_shear_trigger_modifier"
+						"durability"	"%durability_shear_trigger"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_shear_trigger_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability_down"
+						"amount"		"1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_shear_trigger_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_shear_trigger_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"RemoveModifier"
+			        {
+			            "ModifierName" "bvo_squall_skill_0_shear_trigger_crit_buff_modifier"
+			            "Target" "CASTER"
+			        }
+					"Random"
+					{
+						"Chance"			"%chance_shear_trigger"
+						"OnSuccess"
+						{
+							"ApplyModifier"
+			                {
+			                    "ModifierName" "bvo_squall_skill_0_shear_trigger_crit_buff_modifier"
+			                    "Target"    	"CASTER"    
+			                }
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_shear_trigger_crit_buff_modifier"
+			{
+			    "IsHidden"  "1"
+			    "Properties"
+			    {
+			        "MODIFIER_PROPERTY_PREATTACK_CRITICALSTRIKE" "%multi_shear_trigger"
+			    }
+
+			    "OnAttackLanded"
+			    {
+			        "RemoveModifier"
+			        {
+			            "ModifierName"  "bvo_squall_skill_0_shear_trigger_crit_buff_modifier"
+			            "Target"    "CASTER"
+			        }
+			    }
+			}
+
+			//Flame Saber
+			"bvo_squall_skill_0_flame_saber_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"EffectName"		"particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability"
+						"modifier"		"bvo_squall_skill_0_flame_saber_modifier"
+						"durability"	"%durability_flame_saber"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_flame_saber_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability_down"
+						"amount"		"1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_flame_saber_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_flame_saber_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"%chance_flame_saber"
+						"OnSuccess"
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+								"Function"		"bvo_squall_skill_0_flame_saber_damage"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			//Punishment
+			"bvo_squall_skill_0_punishment_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"EffectName"		"particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability"
+						"modifier"		"bvo_squall_skill_0_punishment_modifier"
+						"durability"	"%durability_punishment"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_punishment_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability_down"
+						"amount"		"1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_punishment_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_punishment_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+
+				"OnAttackLanded"
+				{
+					"Random"
+					{
+						"Chance"			"%chance_punishment"
+						"OnSuccess"
+						{
+							"Damage"
+							{
+								"Target"		"TARGET"
+								"Type"			"DAMAGE_TYPE_PHYSICAL"
+								"Damage"		"%damage_punishment"
+							}
+							"Stun"
+							{
+								"Duration"   "%stun_punishment"
+								"Target" 	 "TARGET"
+							}
+						}
+						"OnFailure"
+						{
+						}
+					}
+				}
+			}
+
+			//Lionheart
+			"bvo_squall_skill_0_lionheart_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"EffectName"		"particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+				"EffectAttachType"	"attach_hitloc"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability"
+						"modifier"		"bvo_squall_skill_0_lionheart_modifier"
+						"durability"	"%durability_lionheart"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_lionheart_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/squall/ability_squall_0.lua"
+						"Function"		"bvo_squall_skill_0_durability_down"
+						"amount"		"1"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_squall_skill_0_lionheart_buff_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+			}
+
+			"bvo_squall_skill_0_lionheart_buff_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%damage_lionheart"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_magnataur/magnataur_empower.vpcf"
+			"particle"  "particles/custom/zaraki/zaraki_trail_ribbon_rev.vpcf"
+			"particle"  "particles/units/heroes/hero_ancient_apparition/ancient_apparition_chilling_touch_buff.vpcf"
+			"particle"  "particles/units/heroes/hero_ember_spirit/ember_spirit_flameguard.vpcf"
+		}
+	}
+
+	"bvo_squall_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_squall_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100"
+		"AbilityCooldown"						"16 14 12 10 8 6"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance_revolver"				"75 70 60 45 35 25"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance_shear_trigger"			"20 25 25 25 25 25"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance_flame_saber"			"5 5 10 15 20 20"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance_punishment"				"0 0 5 10 10 15"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"chance_lionheart"				"0 0 0 5 10 15"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/squall/ability_squall_1.lua"
+				"Function"		"bvo_squall_skill_1"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Alchemist.ChemicalRage.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_alchemist.vsndevts"
+		}
+	}
+
+	"bvo_squall_skill_2"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/squall/bvo_squall_skill_2"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_squall_skill_2"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"12"
+		"AbilityCastRange"						"700"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"agi_multi"			"5"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"durability_cost"	"3"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_revolver"			"0"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_shear_trigger"	"20"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_flame_saber"		"35"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_punishment"		"50"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_lionheart"		"100"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_magnataur/magnataur_shockwave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_magnataur.vsndevts"
+		}
+	}
+
+	"bvo_squall_skill_3"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/squall/bvo_squall_skill_3"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_squall_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"30"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"4 5 6 7 8"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"agi_multi"			"4 5 6 7 8"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"durability_cost"	"6"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"1000"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_revolver"			"0"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_shear_trigger"	"10"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_flame_saber"		"30"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_punishment"		"50"
+			}
+			"09"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_lionheart"		"70"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_invoker/invoker_deafening_blast.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+		}
+	}
+
+	"bvo_squall_skill_4"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/squall/bvo_squall_skill_4"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_squall_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"150"
+		"AbilityCastPoint"						"0.2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60 55 50 45 40"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"str_multi"			"2.8"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"2.8"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"durability_cost"	"3"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"hit_amount"		"7"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_revolver"			"20"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_shear_trigger"	"30"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_flame_saber"		"40"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_punishment"		"50"
+			}
+			"09"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_multi_lionheart"		"75"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_vendetta_blood.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts"
+		}
+	}
+
+	"bvo_squall_skill_4_empty"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_squall_skill_4_empty"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"0.0"
+	}
+
+	"bvo_squall_skill_4_pull_trigger"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_IGNORE_CHANNEL | DOTA_ABILITY_BEHAVIOR_IGNORE_PSEUDO_QUEUE | DOTA_ABILITY_BEHAVIOR_UNRESTRICTED"
+		"AbilityTextureName"					"icons/bvo_squall_skill_4_pull_trigger"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"0.0"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/squall/ability_squall_4.lua"
+				"Function"		"bvo_squall_skill_4_trigger"
+			}
+		}
+	}
+
+	"bvo_squall_skill_5"
+	{
+		"BaseClass"								"ability_lua"
+		"ScriptFile"					        "heroes/squall/bvo_squall_skill_5"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_squall_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"150"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"500"
+		"AbilityCooldown"						"140 130 120 110 100"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"40"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"agi_multi"			"40"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"1500"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+		}
+	}
+
+	//Mayuri
+	"bvo_mayuri_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"60"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/mayuri/ability_mayuri_0.lua"
+				"Function"		"bvo_mayuri_skill_0"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_mayuri_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_1"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastRange"				"800"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AbilityCooldown"				"15"
+		"AbilityManaCost"				"100 110 120 130 140 150"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"2.5 3.0 3.5 4.0 4.5 5.0"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"400"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"autocast"			"3.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/mayuri/ability_mayuri_1.lua"
+				"Function"		"bvo_mayuri_skill_1"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Techies.RemoteMine.Toss"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/newplayer_fx/npx_moveto_arrow.vpcf"
+			"particle"  "particles/units/heroes/hero_techies/techies_remote_mines_detonate.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_gyrocopter.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_techies.vsndevts"
+		}
+	}
+
+	"bvo_mayuri_skill_1_cast"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_1_cast"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AbilityCooldown"				"1.0"
+		"AnimationPlaybackRate"			"2.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/mayuri/ability_mayuri_1.lua"
+				"Function"		"bvo_mayuri_skill_1_cast"
+			}
+		}
+	}
+
+	"bvo_mayuri_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_2"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"425"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AbilityCooldown"						"15"
+		"AbilityManaCost"						"180"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"400 475 550 625 700"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"stun"				"1.75"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/mayuri/ability_mayuri_2.lua"
+				"Function"					"bvo_mayuri_skill_2"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_mayuri_skill_2_stun_modifier"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"%stun"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_mayuri_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/units/heroes/hero_bloodseeker/bloodseeker_rupture_nuke.vpcf"
+		}
+	}
+
+	"bvo_mayuri_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"0.5"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"85 80 75 70 65"
+		"AbilityCastRange"						"500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"1.0"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"1.0"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"12"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_mayuri_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/items_fx/bottle.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/mayuri/ability_mayuri_3.lua"
+						"Function"		"bvo_mayuri_skill_3"
+					}
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+		    {
+		    	"EffectName"		"Hero_Alchemist.UnstableConcoction.Throw"
+		    	"Target"			"CASTER"
+		    }
+			"TrackingProjectile"
+			{
+				"Target"           	"TARGET"
+				"EffectName"		"particles/units/heroes/hero_alchemist/alchemist_unstable_concoction_projectile.vpcf"
+				"Dodgeable"			"0"
+				"ProvidesVision"	"0"
+				"VisionRadius"		"10"
+				"MoveSpeed"        	"1000"
+				"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_mayuri_skill_3_modifier"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/mayuri/ability_mayuri_3.lua"
+				"Function"		"bvo_mayuri_skill_3_init"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Alchemist.UnstableConcoction.Stun"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_omniknight/omniknight_purification.vpcf"
+			"particle" "particles/items_fx/bottle.vpcf"
+			"particle"  "particles/units/heroes/hero_alchemist/alchemist_unstable_concoction_projectile.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_alchemist.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_omniknight.vsndevts"
+		}
+	}
+
+	"bvo_mayuri_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"70"
+		"AbilityCastRange"						"500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"800 900 1000 1100 1200"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"1.2 1.4 1.6 1.8 2.0"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"7"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"slow"				"-40"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_mayuri_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_viper/viper_viper_strike_debuff.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/mayuri/ability_mayuri_4.lua"
+						"Function"		"bvo_mayuri_skill_4"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_Viper.CorrosiveSkin"
+						"Target" 		"TARGET"
+					}
+				}
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%slow" 
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+		    {
+		    	"EffectName"		"Hero_Alchemist.UnstableConcoction.Throw"
+		    	"Target"			"CASTER"
+		    }
+			"TrackingProjectile"
+			{
+				"Target"           	"TARGET"
+				"EffectName"		"particles/units/heroes/hero_alchemist/alchemist_unstable_concoction_projectile.vpcf"
+				"Dodgeable"			"1"
+				"ProvidesVision"	"0"
+				"VisionRadius"		"10"
+				"MoveSpeed"        	"1400"
+				"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_mayuri_skill_4_modifier"
+				"Target"		"TARGET"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Alchemist.UnstableConcoction.Stun"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_MAGICAL"
+				"Damage"		"%damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_viper/viper_viper_strike_debuff.vpcf"
+			"particle"  "particles/units/heroes/hero_alchemist/alchemist_unstable_concoction_projectile.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_alchemist.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_viper.vsndevts"
+		}
+	}
+
+	"bvo_mayuri_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_mayuri_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"450"
+		"AbilityCooldown"						"130"
+		"AbilityCastRange"						"300"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"2000"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"10.0 12.5 15.0 17.5 20.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_mayuri_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_mayuri_skill_5_smoke_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"EffectName"		"particles/dark_smoke_test.vpcf"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.MayuriSkill5"
+				"Target" 		"TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/mayuri/ability_mayuri_5.lua"
+				"Function"		"bvo_mayuri_skill_5"
+			}
+		}
+
+		"precache"
+		{
+			"model" "models/hero_mayuri/unit_mayuri_bankai_base.vmdl"
+			"particle"  "particles/custom/mayuri/mayuri_summon_wolves_spawn.vpcf"
+			"particle"  "particles/units/heroes/hero_life_stealer/life_stealer_infest_emerge_bloody.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_life_stealer.vsndevts"
+		}
+	}
+
+	//Law
+	"bvo_law_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_BOTH"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityTextureName"					"icons/bvo_law_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.0"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"5"
+		"AbilityManaCost"				"45"
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_0.lua"
+				"Function"		"bvo_law_skill_0"
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_vengefulspirit.vsndevts"
+		}
+	}
+
+	"bvo_law_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_law_skill_1"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"24"
+		"AbilityManaCost"				"100"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"16"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"550 600 650 700 750 800"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius_extra"		"74 79 84 89 95 102"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"slow"				"-30"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"speed"				"30"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_1.lua"
+				"Function"		"bvo_law_skill_1"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_law_skill_1_aura_ally_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+		
+				"Aura"          	"bvo_law_skill_1_ally_modifier"
+				"Aura_Radius"   	"%radius"
+				"Aura_Teams"    	"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+				"Aura_Types"    	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"    	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"Aura_ApplyToCaster" "1"
+			}
+
+			"bvo_law_skill_1_aura_enemy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+		
+				"Aura"          	"bvo_law_skill_1_enemy_modifier"
+				"Aura_Radius"   	"%radius"
+				"Aura_Teams"    	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"    	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"    	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"Aura_ApplyToCaster" "1"
+			}
+
+			"bvo_law_skill_1_ally_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%speed"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%speed"
+				}
+			}
+
+			"bvo_law_skill_1_enemy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%slow"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%slow"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/law/law_skill_0_room.vpcf"
+		}
+	}
+
+	"bvo_law_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_law_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRange"				"900"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"18"
+		"AbilityManaCost"				"160"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"375"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"1 1.5 2 2.5 3"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"room_multi"		"1 1.5 2 2.5 3"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"stun"				"0.1"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_PhantomAssassin.CoupDeGrace.Arcana"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_law_skill_2_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"0.5"
+			}
+			"TrackingProjectile"
+			{
+				"Target"           	"TARGET"
+				"EffectName"		"particles/econ/items/sniper/sniper_charlie/sniper_assassinate_charlie.vpcf"
+				"Dodgeable"			"1"
+				"ProvidesVision"	"1"
+				"VisionRadius"		"300"
+				"MoveSpeed"        	"2000"
+				"SourceAttachment"	"DOTA_PROJECTILE_ATTACHMENT_ATTACK_1"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_2.lua"
+				"Function"		"bvo_law_skill_2"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_law_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+		
+				"EffectName"		"particles/econ/items/sniper/sniper_charlie/sniper_crosshair_b_charlie.vpcf"
+				"EffectAttachType"	"follow_overhead"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"FireSound"
+			{
+				"EffectName"	"Hero_Sniper.AssassinateDamage"
+				"Target" 		"TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_2.lua"
+				"Function"		"bvo_law_skill_2_damage"
+			}
+			"Stun"
+			{
+				"Duration"   "%stun"
+				"Target" 	 "TARGET"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/sniper/sniper_charlie/sniper_assassinate_charlie.vpcf"
+			"particle"  "particles/econ/items/sniper/sniper_charlie/sniper_crosshair_b_charlie.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_sniper.vsndevts"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts"
+		}
+	}
+
+	"bvo_law_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_law_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"150"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"40"
+		"AbilityManaCost"				"275"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"hp_damage"			"3.5 4.0 4.5 5.0 5.5"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"9.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Terrorblade.Sunder.Cast"
+				"Target" 		"TARGET"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_law_skill_3_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_law_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_pugna/pugna_decrepify.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "1.0"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/law/ability_law_3.lua"
+						"Function"		"bvo_law_skill_3"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_pugna/pugna_decrepify.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_terrorblade.vsndevts"
+		}
+	}
+
+	"bvo_law_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_law_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"150"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ATTACK"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"70"
+		"AbilityManaCost"				"350"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"parts"				"4"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"6.0 6.5 7.0 7.5 8.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_NyxAssassin.ManaBurn.Cast"
+				"Target" 		"TARGET"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_law_skill_4_modifier"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_law_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/law/ability_law_4.lua"
+						"Function"		"bvo_law_skill_4"
+					}			
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/law/ability_law_4.lua"
+						"Function"		"bvo_law_skill_4_end"
+					}		
+				}
+			}
+
+			"bvo_law_skill_4_wait_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"			"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_UNIT_COLLISION"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NOT_ON_MINIMAP"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_UNSELECTABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_OUT_OF_GAME"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_law_skill_4_part_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/law/ability_law_4.lua"
+						"Function"		"bvo_law_skill_4_part_die"
+					}
+				}			
+			}
+
+			"bvo_law_skill_4_tip_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"		
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_4.lua"
+				"Function"		"bvo_law_skill_4_hit"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_mana_burn.vpcf"
+			"soundfile"  "soundevents/game_sounds_heroes/game_sounds_nyx_assassin.vsndevts"
+		}
+	}
+
+	"bvo_law_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_law_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"				"150"
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"110 105 100 95 90"
+		"AbilityManaCost"				"425"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"2000"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"lvl_multi"			"10 15 20 25 30"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"10.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"hero_bloodseeker.bloodRite"
+				"Target" 		"TARGET"
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/econ/items/bloodseeker/bloodseeker_eztzhok_weapon/bloodseeker_bloodbath_eztzhok.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/law/ability_law_5.lua"
+				"Function"		"bvo_law_skill_5"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_law_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/bloodseeker/bloodseeker_eztzhok_weapon/bloodseeker_bloodbath_eztzhok.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bloodseeker.vsndevts"
+		}
+	}
+
+	//Whitebeard
+	"bvo_whitebeard_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCooldown"						"15"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"health_percent"	"25"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"5.0"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage_reduction"	"-80"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_0_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsBuff"			"0"
+		
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_0.lua"
+						"Function"		"bvo_whitebeard_skill_0"
+						"damage"		"%attack_damage"
+					}
+				}	
+			}
+
+			"bvo_whitebeard_skill_0_buff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+		
+				"StatusEffectName" 		"particles/status_fx/status_effect_medusa_stone_gaze.vpcf"
+				"StatusEffectPriority"  "10"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "%damage_reduction"
+				}	
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/status_fx/status_effect_medusa_stone_gaze.vpcf"
+		}
+	}
+
+	"bvo_whitebeard_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"				"0.3"
+		"AbilityCastRange"				"1200"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"			"1.8"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"12"
+		"AbilityManaCost"				"160"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"225 350 475 600 725 850"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"0.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Ability.Avalanche"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+				"EffectAttachType"  "attach_attack2"
+				"Target"            "CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.WhitebeardSkill1"
+				"Target" 		"CASTER"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/custom/whitebeard/whitebeard_skill_1_projectile.vpcf"
+				"MoveSpeed"		 "1800"
+				"StartRadius"	 "150"
+				"StartPosition"  "attach_attack2"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "1200"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"						
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "250"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"FireSound"
+			{
+				"EffectName"	"Hero_ElderTitan.AncestralSpirit.Damage"
+				"Target" 		"TARGET"
+			}
+			"Damage"
+			{
+				"Target"		"TARGET"
+				"Type"			"DAMAGE_TYPE_PHYSICAL"
+				"Damage"		"%damage"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_whitebeard_skill_1_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-40" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_tiny.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_elder_titan.vsndevts"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_1_projectile.vpcf"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+		}
+	}
+
+	"bvo_whitebeard_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_2"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"				"0.6"
+		"AbilityCastRange"				"400"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK2"
+		"AnimationPlaybackRate"			"0.6"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"36"
+		"AbilityManaCost"				"220"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"400"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"2 3 4 5 6"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"350"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"0.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+				"EffectAttachType"  "attach_attack1"
+				"Target"            "CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.WhitebeardSkill1"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_elder_titan/elder_titan_echo_stomp_physical.vpcf"
+				"EffectAttachType"  "world_origin"
+				"TargetPoint"       "POINT"
+				"ControlPoints"
+				{
+					"01"	"%radius 0 0"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_ElderTitan.EchoStomp"
+				"Target" 		"CASTER"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_whitebeard_skill_2_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"%duration"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_2.lua"
+						"Function"		"bvo_whitebeard_skill_2"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_2_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-80" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+			"particle"  "particles/units/heroes/hero_elder_titan/elder_titan_echo_stomp_physical.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_elder_titan.vsndevts"
+		}
+	}
+
+	"bvo_whitebeard_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_3"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.6"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"80 75 70 65 60"
+		"AbilityManaCost"				"250"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"10"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"30"
+			}
+			
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"600"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"bonus_damage"		"120 180 240 300 360"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"stun_duration"		"1.0"
+			}
+			"06"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"cleave_percent"	"35"
+			}
+			"07"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"cleave_radius"		"275"
+			}
+			"08"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"height"			"400"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_3.lua"
+						"Function"		"bvo_whitebeard_skill_3_stun"
+					}
+				}
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_whitebeard_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/whitebeard/ability_whitebeard_3.lua"
+				"Function"		"bvo_whitebeard_skill_3_effect"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Invoker.Tornado.Cast"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"EffectName"		"particles/custom/whitebeard/whitebeard_skill_3_buff.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"OnAttackLanded"
+				{
+					"CleaveAttack"
+					{
+						"CleavePercent"         "%cleave_percent"
+						"CleaveRadius"          "%cleave_radius"
+						"CleaveEffect"          "particles/units/heroes/hero_sven/sven_spell_great_cleave.vpcf"
+					}
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE" "%bonus_damage"
+				}
+			}
+
+			"bvo_whitebeard_skill_3_hero_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnCreated"
+				{
+					"RemoveModifier"
+					{
+						"Target"			"TARGET"
+						"ModifierName"		"modifier_knockback"
+					}
+
+					"Knockback"
+					{
+						"Target"            "TARGET"
+						"Center" 	        "TARGET"
+						"Distance"	        "0"
+						"Duration"	        "0.5"//%stun_duration / 2
+						"Height"	        "200"//%stun_duration * %height / 2
+						"IsFixedDistance"	"1"
+						"ShouldStun"        "1"	
+					}
+				}
+
+				"OnDestroy"
+				{
+					"FireEffect"
+					{
+						"EffectName"		"particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+						"EffectAttachType" 	"follow_origin"
+						"EffectRadius"		"125"
+						"Target" 			"TARGET"
+						"ControlPoints"
+						{
+							"01"	"125 0 125"
+						}
+					}
+
+					"FireSound"
+					{
+						"EffectName"	"Hero_ElderTitan.AncestralSpirit.Damage"
+						"Target" 		"TARGET"
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_3.lua"
+						"Function"		"bvo_whitebeard_skill_3"
+						"multi"			"1"
+					}
+				}
+			}
+
+			"bvo_whitebeard_skill_3_creep_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnCreated"
+				{
+					"RemoveModifier"
+					{
+						"Target"			"TARGET"
+						"ModifierName"		"modifier_knockback"
+					}
+
+					"Knockback"
+					{
+						"Target"            "TARGET"
+						"Center" 	        "TARGET"
+						"Distance"	        "0"
+						"Duration"	        "%stun_duration"
+						"Height"	        "400"//%stun_duration * %height
+						"IsFixedDistance"	"1"
+						"ShouldStun"        "1"	
+					}
+				}
+
+				"OnDestroy"
+				{
+					"FireSound"
+					{
+						"EffectName"	"Hero_ElderTitan.AncestralSpirit.Damage"
+						"Target" 		"TARGET"
+					}
+
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_3.lua"
+						"Function"		"bvo_whitebeard_skill_3"
+						"multi"			"2"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_3_buff.vpcf"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_3.vpcf"
+			"particle"  "particles/units/heroes/hero_sven/sven_spell_great_cleave.vpcf"
+			"particle"  "particles/units/heroes/hero_centaur/centaur_warstomp.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_invoker.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_centaur.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_elder_titan.vsndevts"
+		}
+	}
+
+	"bvo_whitebeard_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_4"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.9"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"90"
+		"AbilityManaCost"				"375"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"6 7 8 9 10"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"1200"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"stun_duration"		"1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/custom/whitebeard/whitebeard_skill_4_crack.vpcf"
+				"EffectAttachType"  "attach_attack1"
+				"Target"            "CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.WhitebeardSkill1"
+				"Target" 		"CASTER"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Leshrac.Split_Earth"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_whitebeard_skill_4_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"%stun_duration"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_4.lua"
+						"Function"		"bvo_whitebeard_skill_4"
+					}
+				}
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/whitebeard/ability_whitebeard_4.lua"
+				"Function"		"bvo_whitebeard_skill_4_effect"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_leshrac/leshrac_split_earth.vpcf"
+			"particle"  "particles/custom/whitebeard_skill_4.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_4_crack.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_leshrac.vsndevts"
+		}
+	}
+
+	"bvo_whitebeard_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_whitebeard_skill_5"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.6"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilityCastRange"				"200"
+
+		"AbilityCooldown"				"150"
+		"AbilityManaCost"				"500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"15 20 25 30 35"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"1.5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Ability.TossThrow"
+				"Target" 		"TARGET"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_whitebeard_skill_5_self_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_whitebeard_skill_5_enemy_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_whitebeard_skill_5_self_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/custom/whitebeard_skill_5_self.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_whitebeard_skill_5_enemy_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"RemoveModifier"
+					{
+						"Target"			"TARGET"
+						"ModifierName"		"modifier_knockback"
+					}
+
+					"Knockback"
+					{
+						"Target"            "TARGET"
+						"Center" 	        "TARGET"
+						"Distance"	        "0"
+						"Duration"	        "1.5"
+						"Height"	        "800"
+						"IsFixedDistance"	"1"
+						"ShouldStun"        "1"	
+					}
+					"DelayedAction"
+					{
+						"Delay"     "1.1"
+						"Action"    
+						{
+							"RunScript"
+							{
+								"ScriptFile"	"heroes/whitebeard/ability_whitebeard_5.lua"
+								"Function"		"bvo_whitebeard_skill_5"
+							}
+						}
+					}
+				}
+
+				"OnDestroy"
+				{
+					"FireEffect"
+					{
+						"EffectName"        "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+						"EffectAttachType"  "attach_attack1"
+						"Target"
+			            {
+			                "Center" "TARGET"
+			                "Flags" "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+			            }
+					}
+					"FireSound"
+					{
+						"EffectName"	"BleachVsOnePieceReborn.WhitebeardSkill1"
+						"Target"
+			            {
+			                "Center" "TARGET"
+			                "Flags" "DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+			            }
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/whitebeard/ability_whitebeard_5.lua"
+						"Function"		"bvo_whitebeard_skill_5_damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_whitebeard_skill_5_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"1.0"
+					}
+				}
+			}
+
+			"bvo_whitebeard_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned_old.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "-80" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_5_hitcrack.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"  "particles/custom/whitebeard_skill_5_self.vpcf"
+			"particle"  "particles/custom/whitebeard/whitebeard_skill_1_crack.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_tiny.vsndevts"
+		}
+	}
+
+	//Aizen
+	"bvo_aizen_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75"
+		"AbilityCooldown"						"4.5"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/aizen/ability_aizen_0.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"		"CASTER"
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"		"CASTER"
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_aizen_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150 175 200 225 250 275"
+		"AbilityCooldown"						"14 14 13 13 12 12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 250 300 350 400 450"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"1.0 1.5 2.0 2.5 3.0 3.5"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"450"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"slow"							"-30"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration"						"3.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"		"Hero_Abaddon.AphoticShield.Destroy"
+				"Target"			"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/aizen/ability_aizen_1.lua"
+						"Function"		"bvo_aizen_skill_1_damage"
+					}
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_aizen_skill_1_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"%duration"
+					}
+				}
+			}
+			"AttachEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_abaddon/abaddon_aphotic_shield_explosion.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aizen_skill_1_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%slow" 
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" 	"particles/units/heroes/hero_abaddon/abaddon_aphotic_shield_explosion.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_abaddon.vsndevts"
+		}
+	}
+
+	"bvo_aizen_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_2"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"400 450 500 550 600"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AbilityCooldown"						"17.5"
+		"AbilityManaCost"						"180"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"3.5"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"range"				"400 450 500 550 600"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"0.75"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/phantom_assassin/phantom_assassin_weapon_runed_scythe/phantom_assassin_attack_blur_crit_runed_scythe.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/aizen/ability_aizen_2.lua"
+				"Function"					"bvo_aizen_skill_2"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aizen_skill_2_stun_modifier"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"%duration"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_aizen_skill_2_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/phantom_assassin/phantom_assassin_weapon_runed_scythe/phantom_assassin_attack_blur_crit_runed_scythe.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_aizen_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"35"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"armor"							"40"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"6 7 8 9 10"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Oracle.FalsePromise.Cast"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/omniknight/hammer_ti6_immortal/omniknight_purification_ti6_immortal.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aizen_skill_3_modifier"
+				"Target"
+	            {
+	                "Center" 	"CASTER"
+	                "Flags" 	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aizen_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/units/heroes/hero_omniknight/omniknight_repel_buff_b.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%armor"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/omniknight/hammer_ti6_immortal/omniknight_purification_ti6_immortal.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_oracle.vsndevts"
+		}
+	}
+
+	"bvo_aizen_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"300"
+		"AbilityCooldown"						"60 55 50 45 40"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"bonus_damage"		"1500 1750 2000 2250 2500"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"8.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_aizen_skill_4_modifier"
+				"Target"
+	            {
+	                "Center" 	"CASTER"
+	                "Flags" 	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_TemplarAssassin.Meld"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_aizen_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"OnCreated"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target"		"CASTER"
+						"Duration"		"%duration"
+					}
+				}
+
+				"OnAttackLanded"
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PHYSICAL"
+						"Damage"		"%bonus_damage"
+					}
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_aizen_skill_4_modifier"
+						"Target" 		"CASTER"
+					}
+					"FireSound"
+					{
+						"EffectName"	"Hero_TemplarAssassin.Meld.Attack"
+						"Target"
+						{
+							"Center"  	"TARGET"
+							"Flags"		"DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+				}
+
+				"OnAbilityExecuted"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"bvo_aizen_skill_4_modifier"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RemoveModifier"
+					{
+						"ModifierName"	"modifier_invisible"
+						"Target" 		"CASTER"
+					}
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_NO_UNIT_COLLISION"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_templar_assassin.vsndevts"
+		}
+	}
+
+	"bvo_aizen_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_aizen_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"425"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"						"120"
+		"AbilityManaCost"						"450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"2000"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"agi_multi"			"10.0 12.5 15.0 17.5 20.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/aizen/ability_aizen_5.lua"
+				"Function"					"bvo_aizen_skill_5"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_aizen_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_aizen_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/aizen/aizen_skill_5.vpcf"
+		}
+	}
+
+	//Rory
+	"bvo_rory_skill_0" 
+	{
+		"BaseClass" 					"ability_datadriven"
+
+		"MaxLevel" 						"1"
+		"AbilityBehavior" 				"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_AURA"
+		"AbilityTextureName"					"icons/bvo_rory_skill_0"
+		"AOERadius"						"%radius"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"900"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"as"				"3"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"ms"				"3"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"10"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rory_skill_0_aura_modifier"
+			{
+				"Passive"   "1"
+				"IsHidden"  "1"
+
+				"Aura"          	"bvo_rory_skill_0_modifier"
+				"Aura_Radius"   	"%radius"
+				"Aura_Teams"    	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"    	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+			}
+
+			"bvo_rory_skill_0_modifier"
+			{
+				"Passive"   "0"
+				"IsHidden"  "1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_0.lua"
+						"Function"		"bvo_rory_skill_0"
+					}
+				}
+			}
+
+			"bvo_rory_skill_0_buff_modifier"
+			{
+				"Duration"	"%duration"
+				"Passive"   "0"
+				"IsHidden"  "0"
+				"IsBuff"	"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%as"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%ms" 
+				}
+			}
+		}
+	}
+
+	"bvo_rory_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_rory_skill_1"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.3"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"125"
+		"AbilityCooldown"						"12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"base_damage"					"100 150 200 250 300 350"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage_per_stack"				"75"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"max_stack_use"					"4 6 8 10 12"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"375"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rory/ability_rory_1.lua"
+				"Function"		"bvo_rory_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/axe/axe_weapon_practos/axe_attack_blur_counterhelix_practos.vpcf"
+		}
+	}
+
+	"bvo_rory_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_rory_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE_RARE"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"30 32 34 36 38"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"self_damage_percent"			"30"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"max_stack_get"					"8 12 16 20 24"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"over_time"						"4"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"DOTA_Item.SoulRing.Activate"
+				"Target" 		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rory/ability_rory_2.lua"
+				"Function"		"bvo_rory_skill_2"
+			}
+			"Damage"
+			{
+				"Target"		"CASTER"
+				"Type"			"DAMAGE_TYPE_PURE"
+				"Damage"		"%self_damage_percent"
+				"CurrentHealthPercentBasedDamage"		"1"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_rory_skill_2_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%over_time"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rory_skill_2_modifier"
+			{
+				"Passive" "0"  
+				"IsHidden" "0"
+
+				"ThinkInterval" 		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_2.lua"
+						"Function"		"bvo_rory_skill_2_heal"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/items2_fx/soul_ring.vpcf"
+		}
+	}
+
+	"bvo_rory_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_rory_skill_3"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"1100"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"250"
+		"AbilityCooldown"						"45"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_as_damage_per_stack"		"0.3"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"raw_damage_per_stack"			"75"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"base_damage"					"225"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"max_stack_use"					"4 6 8 10 12"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target"			"POINT"
+				"EffectName"		"particles/custom/rory/rory_skill_3_silence_wave.vpcf"
+				"MoveSpeed"			"1800"
+				"StartRadius"		"250"
+				"StartPosition"		"attach_attack1"
+				"EndRadius"			"250"
+				"FixedDistance"		"900"
+				"TargetTeams"		"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"		"DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"		"DOTA_UNIT_TARGET_FLAG_NONE"
+				"HasFrontalCone"	"0"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_DrowRanger.Silence"
+				"Target"			"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rory/ability_rory_3.lua"
+				"Function"		"bvo_rory_skill_3"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rory/ability_rory_3.lua"
+				"Function"		"bvo_rory_skill_3_damage"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/rory/rory_skill_3_silence_wave.vpcf"
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_drowranger.vsndevts"
+		}
+	}
+
+	"bvo_rory_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityTextureName"					"icons/bvo_rory_skill_4"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AnimationPlaybackRate"					"1.0"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityCastPoint"						"1.0"
+		"AbilityCastRange"						"250"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE_RARE"
+		"AbilityCooldown"						"65"
+		"AbilityManaCost"						"300"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"duration"						"5.0 5.5 6.0 6.5 7.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/rory/ability_rory_4.lua"
+				"Function"					"bvo_rory_skill_4"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_rory_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_4.lua"
+						"Function"		"bvo_rory_skill_4_damage"
+						"damage"		"%attack_damage"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_4.lua"
+						"Function"		"bvo_rory_skill_4_end"
+					}
+				}
+
+				"ThinkInterval"		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_4.lua"
+						"Function"		"bvo_rory_skill_4_track"
+					}
+				}
+			}
+
+			"bvo_rory_skill_4_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rory/ability_rory_4.lua"
+						"Function"		"bvo_rory_skill_4_end"
+					}
+				}
+			}
+		}
+	}
+
+	"bvo_rory_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_rory_skill_5"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AnimationPlaybackRate"					"1.5"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastRange"						"325"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AbilityCooldown"						"120 110 100 90 80"
+		"AbilityManaCost"						"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_as_damage_per_stack"		"0.4"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"raw_damage_per_stack"			"40"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"base_damage"					"1000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"				"heroes/rory/ability_rory_5.lua"
+				"Function"					"bvo_rory_skill_5"
+			}
+		}
+		
+		"Modifiers"
+		{
+			"bvo_rory_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_rory_skill_5_modifier_enemy"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_INVULNERABLE"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_COMMAND_RESTRICTED"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+
+			"bvo_rory_skill_5_stun_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_leshrac.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_brewmaster.vsndevts"
+		}
+	}
+
+	//Ulquiorra
+	"bvo_ulquiorra_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"45"
+		"AbilityCooldown"						"5.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"blink_range"			"600"
+			}
+		
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"min_blink_range"		"600"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ability_ichigo.lua"
+				"Function"		"Blink"
+				"Target"		"POINT"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_out"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_start.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"attach_hitloc"
+			}
+
+			"FireSound"
+			{
+				"EffectName"	"Hero_Antimage.Blink_in"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+
+			"AttachEffect"
+			{
+				"EffectName"	"particles/custom/misc/general_blink_end.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"follow_origin"
+			}
+		}
+	}
+
+	"bvo_ulquiorra_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_1"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"900"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"90"
+		"AbilityCooldown"						"8"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"325 450 575 700 825 950"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"175"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"AttachEffect"
+			{
+				"EffectName"	"particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn_g.vpcf"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"EffectAttachType"	"attach_attack1"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_1.lua"
+				"Function"		"bvo_ulquiorra_skill_1"
+				"Target"		"POINT"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"POINT"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_MAGICAL"
+						"Damage"		"%damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_lycan/lycan_summon_wolves_spawn_g.vpcf"
+			"particle"  "particles/custom/ulquiorra/ulquiorra_skill_1.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_ember_spirit.vsndevts"
+		}
+	}
+
+	"bvo_ulquiorra_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"armor_bonus"					"4 8 12 16 20"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"resist_bonus"					"4 8 12 16 20"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ulquiorra_skill_2_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS" "%resist_bonus"
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"	"%armor_bonus"
+				}
+			}
+		}
+	}
+
+	"bvo_ulquiorra_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"220"
+		"AbilityCooldown"						"32.0"
+		"AbilityCastRange"						"1500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"600 800 1000 1200 1400"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"1"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/custom/ulquiorra/ulquiorra_skill_3.vpcf"
+				"MoveSpeed" "2500"
+				"StartRadius" "300"
+				"EndRadius" "300"
+				"FixedDistance" "1500"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tinker.Laser"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"FireSound"
+			{
+				"EffectName"	"Hero_Tinker.LaserImpact"
+				"Target"		"TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_3.lua"
+				"Function"		"bvo_ulquiorra_skill_3"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/ulquiorra/ulquiorra_skill_3.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_gyrocopter.vsndevts"
+		}
+	}
+
+	"bvo_ulquiorra_skill_4"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_4"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityChannelTime"			"6.0"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"2"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"60 62 64 66 68"
+		"AbilityManaCost"				"300"
+		"AbilityCastRange"				"%length"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"damage_tick"			"400 600 800 1000 1200"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"length"				"1400"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"width"					"196"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"slow"					"-70"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_4.lua"
+				"Function"		"bvo_ulquiorra_skill_4"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_ulquiorra_skill_4_channel_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"6.0"
+			}
+			"FireSound"
+			{
+				"EffectName"		"Hero_Phoenix.SunRay.Cast"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			
+			"FireSound"
+			{
+				"EffectName"		"Hero_Phoenix.SunRay.Loop"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_ulquiorra_skill_4_channel_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"ThinkInterval"  "0.25"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_4.lua"
+						"Function"		"bvo_ulquiorra_skill_4_tick"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"FireSound"
+					{
+						"EffectName"		"Hero_Phoenix.SunRay.Stop"
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE | DOTA_UNIT_TARGET_FLAG_DEAD"
+						}
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_4.lua"
+						"Function"		"bvo_ulquiorra_skill_4_end"
+					}
+				}
+			}
+
+			"bvo_ulquiorra_skill_4_slow_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%slow"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%slow" 
+				}
+			}
+		}
+
+		"OnChannelInterrupted"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_ulquiorra_skill_4_channel_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/ulquiorra/ulquiorra_skill_4.vpcf"
+		}
+	}
+
+	"bvo_ulquiorra_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_ulquiorra_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"1.0"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1.0"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"95.0"
+		"AbilityCastRange"						"1400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"1000 1250 1500 1750 2000"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"1.0 1.5 3.0 4.5 6.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"radius"						"825"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_5.lua"
+				"Function"		"bvo_ulquiorra_skill_5"
+				"Target"		"POINT"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Enchantress.Impetus"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/ulquiorra/ability_ulquiorra_5.lua"
+				"Function"		"bvo_ulquiorra_skill_5_hit"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Pugna.NetherBlast"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/ulquiorra_skill_5.vpcf"
+			"particle"  "particles/custom/ulquiorra/ulquiorra_skill_5.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_pugna.vsndevts"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_enchantress.vsndevts"
+		}
+	}
+
+	//Anzu
+	"bvo_anzu_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_0"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"3"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"75"
+		"AbilityCooldown"						"9"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"max_ms"						"550"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"625"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"2"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"slow"							"-100"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"dur_per_hero"					"1.0"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"dur_per_creep"					"0.2"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/anzu/ability_anzu_0.lua"
+				"Function"		"bvo_anzu_skill_0"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_tinker/tinker_rearm.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"FireSound"
+			{
+				"EffectName"	"DOTA_Item.Refresher.Activate"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_anzu_skill_0_buff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/custom/anzu/anzu_skill_0/anzu_skill_0.vpcf"
+				"EffectAttachType"	"follow_origin"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_ABSOLUTE" "%max_ms"
+				}
+			}
+
+			"bvo_anzu_skill_0_debuff_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_silenced.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_PERCENTAGE" "%slow"
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED" "MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_tinker/tinker_rearm.vpcf"
+			"particle"  "particles/custom/anzu/anzu_skill_0/anzu_skill_0.vpcf"
+			"particle"  "particles/generic_gameplay/generic_silenced.vpcf"
+		}
+	}
+
+	"bvo_anzu_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_1"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS | DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"225"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"125 175 225 275 325"
+		"AbilityCooldown"						"30"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"percent"						"10 15 20 25 30 35"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"multiplier"					"2 3 4 5 6 7"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"gold_damage"					"10"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"350"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"aoe_damage_percent"			"50"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/anzu/ability_anzu_1.lua"
+				"Function"		"bvo_anzu_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/items2_fx/hand_of_midas.vpcf"
+			"particle"  "particles/generic_gameplay/rune_bounty_owner.vpcf"
+		}
+	}
+
+	"bvo_anzu_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_2"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CHANNEL_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"175 300 425 550 675"
+		"AbilityCooldown"						"20"
+		"AbilityChannelTime"					"8"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"625 750 875 1000 1125"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"8"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"int_heal"						"1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_anzu_skill_2_channel_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_anzu_skill_2_channel_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/custom/anzu/anzu_skill_2/anzu_skill_3_candy.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"ThinkInterval"  "0.2"
+				"OnIntervalThink"
+				{
+					"FireEffect"
+					{
+						"EffectName"        "particles/econ/items/lanaya/lanaya_epit_trap/templar_assassin_epit_trap_explode_shards_bright.vpcf"
+						"EffectAttachType"  "follow_origin"
+						"Target"
+						{
+							"Center"  	"CASTER"
+							"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+						}
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/anzu/ability_anzu_2.lua"
+						"Function"		"bvo_anzu_skill_2_tick"
+					}
+				}
+			}
+		}
+
+		"OnChannelFinish"
+		{
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_anzu_skill_2_channel_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"1"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/anzu/ability_anzu_2.lua"
+				"Function"		"bvo_anzu_skill_2"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/lanaya/lanaya_epit_trap/templar_assassin_epit_trap_explode_shards_bright.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/anzu/anzu_skill_2/anzu_skill_3_candy.vpcf"
+			"particle" "particles/custom/anzu/anzu_skill_1/anzu_spell_storm_bolt.vpcf"
+		}
+	}
+
+	"bvo_anzu_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.75"
+		"AbilityCastAnimation"					"ACT_DOTA_DIE"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"0"
+		"AbilityCooldown"						"45"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"8"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"damage_per_health"				"0.5 0.7 0.85 0.95 1.0"
+			}
+		}
+
+		"OnAbilityPhaseStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.AnzuSkill3"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_anzu_skill_3_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%duration"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_anzu_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/generic_gameplay/generic_sleep.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"States"
+				{
+					"MODIFIER_STATE_NOT_ON_MINIMAP"	"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_FROZEN"			"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"heroes/anzu/ability_anzu_3.lua"
+						"Function"				"bvo_anzu_skill_3_wake"
+					}
+				}
+
+				"ThinkInterval" 		"0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"			"heroes/anzu/ability_anzu_3.lua"
+						"Function"				"bvo_anzu_skill_3"
+						"RegenPercentPerSecond"	"12.5"
+						"Interval"				"0.03"
+					}
+				}
+			}
+
+			"bvo_anzu_skill_3_sound_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsDebuff"			"0"
+		
+				"OnOrder"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/anzu/ability_anzu_3.lua"
+						"Function"		"bvo_anzu_skill_3_stop"
+					}
+				}
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/anzu/ability_anzu_3.lua"
+						"Function"		"bvo_anzu_skill_3_stop_force"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/generic_gameplay/generic_sleep.vpcf"
+		}
+	}
+
+	"bvo_anzu_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_4"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"325 400 475 550 625"
+		"AbilityCooldown"						"90"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"1000 1100 1200 1300 1400"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"as"							"15 20 25 30 35"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"ms"							"15 20 25 30 35"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"armor"							"4 6 8 10 12"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"resist"						"6 7 8 9 10"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"health_regen"					"10 20 30 40 50"
+			}
+			"08"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"mana_regen"					"5 10 15 20 25"
+			}
+			"09"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"20 40 60 80 100"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"			"heroes/anzu/ability_anzu_4.lua"
+				"Function"				"bvo_anzu_skill_4"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_anzu_skill_4_effect_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"EffectName"		"particles/custom/anzu/anzu_skill_4/anzu_skill_4_aura.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PREATTACK_BONUS_DAMAGE"		"%damage"
+					"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" 	"%as"
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" 	"%ms"
+				    "MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"		"%armor"
+				    "MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS"	"%resist"
+				    "MODIFIER_PROPERTY_HEALTH_REGEN_CONSTANT"		"%health_regen"
+				    "MODIFIER_PROPERTY_MANA_REGEN_CONSTANT"			"%mana_regen"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_templar_assassin.vsndevts"
+			"particle"  "particles/custom/anzu/anzu_skill_4/anzu_skill_4_aura.vpcf"
+		}
+	}
+
+	"bvo_anzu_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityTextureName"					"icons/bvo_anzu_skill_5"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags"				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"700"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200"
+		"AbilityCooldown"						"40 50 60 70 80"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"extra_gold"					"175 225 275 325 375"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"duration"						"20"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"self_damage_percent"			"20 25 30 35 40"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"int_as_gold"					"1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_anzu_skill_5_modifier"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_BountyHunter.WindWalk"
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_anzu_skill_5_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_bounty_hunter/bounty_hunter_track_scroll.vpcf"
+				"EffectAttachType"	"follow_overhead"
+
+				"OnDeath"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/anzu/ability_anzu_5.lua"
+						"Function"		"bvo_anzu_skill_5"
+					}
+				}
+
+				"OnDealDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/anzu/ability_anzu_5.lua"
+						"Function"		"bvo_anzu_skill_5_selfhit"
+						"attack_damage"	"%attack_damage"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_bounty_hunter.vsndevts"
+			"particle" "particles/units/heroes/hero_bounty_hunter/bounty_hunter_track_scroll.vpcf"
+			"particle"  "particles/econ/items/bounty_hunter/bounty_hunter_hunters_hoard/bounty_hunter_hoard_track_reward.vpcf"
+		}
+	}
+
+	//Rem
+	"bvo_rem_skill_0"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityTextureName"					"icons/bvo_rem_skill_0"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"stack_per_percent"			"1.5"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"percent_damage"			"1"
+			}
+			"07"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"percent_hp_regen"			"0.05"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rem_skill_0_modfier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+		
+				"ThinkInterval"  "0.03"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/rem/ability_rem_0.lua"
+						"Function"		"bvo_rem_skill_0"
+					}
+				}
+			}
+
+			"bvo_rem_skill_0_buff_modfier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE"		"%percent_damage"
+				    "MODIFIER_PROPERTY_HEALTH_REGEN_PERCENTAGE"				"%percent_hp_regen"
+				}
+			}
+		}
+	}
+
+	"bvo_rem_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_rem_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastRange"						"500"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"150"
+		"AbilityCooldown"						"12"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"200 300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"1.5 2.0 2.5 3.0 3.5 4.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"450"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rem/ability_rem_1.lua"
+				"Function"		"bvo_rem_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_nyx_assassin/nyx_assassin_vendetta_blood.vpcf"
+		}
+	}
+
+	"bvo_rem_skill_2"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_FRIENDLY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityTextureName"					"icons/bvo_rem_skill_2"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastRange"						"800"
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"200 225 250 275 300"
+		"AbilityCooldown"						"26"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"heal"						"300 350 450 600 800"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"heal_int_multi"			"1.0"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"duration"					"6.0 7.0 8.0 9.0 10.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_oracle/oracle_false_promise_heal.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"Heal"
+			{
+				"Target"        "TARGET"
+				"HealAmount"	"%heal"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rem/ability_rem_2.lua"
+				"Function"		"bvo_rem_skill_2"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_oracle/oracle_false_promise_heal.vpcf"
+			"particle"  "particles/units/heroes/hero_oracle/oracle_purifyingflames.vpcf"
+		}
+	}
+
+	"bvo_rem_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+		"AbilityTextureName"					"icons/bvo_rem_skill_3"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"%fissure_range"
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_4"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"320"
+		"AbilityCooldown"						"46"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"300 400 500 600 700"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"str_multi"					"3.0 3.5 4.0 4.5 5.0"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"fissure_range"				"1000 1100 1200 1300 1400"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"fissure_duration"			"3.0"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"fissure_radius"			"225"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"stun_duration"				"1.0 1.25 1.5 1.75 2.0"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"offset"					"96"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_EarthShaker.Fissure"
+				"Target"		"CASTER"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rem/ability_rem_3.lua"
+				"Function"		"bvo_rem_skill_3"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rem_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  	"particles/generic_gameplay/generic_stunned.vpcf"
+			"particle"		"particles/units/heroes/hero_earthshaker/earthshaker_fissure.vpcf"
+			"soundfile"		"sounds/weapons/hero/earthshaker/fissure.vsnd"
+		}
+	}
+
+	"bvo_rem_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_DIRECTIONAL"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_rem_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"%cast_range"
+		"AbilityCastPoint"						"0.4"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"400"
+		"AbilityCooldown"						"70"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"damage"					"400 550 700 850 1000"
+			}
+			"02"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"agi_multi"					"6.0 6.25 6.75 7.5 8.5"
+			}
+			"03"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"knockback_duration"		"1.5"
+			}
+			"04"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"knockback_speed"			"150"
+			}
+			"05"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"projectile_distance"		"800 1000 1200 1400 1600"
+			}
+			"06"
+			{
+				"var_type"					"FIELD_INTEGER"
+				"cast_range"				"1000 1200 1400 1600 1800"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Morphling.Waveform"
+				"Target" 		"CASTER"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_tidehunter/tidehunter_gush_upgrade.vpcf"
+				"MoveSpeed"		 "1000"
+				"StartRadius"	 "100"
+				"StartPosition"  "attach_attack2"
+				"EndRadius"      "400"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "%projectile_distance"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_BASIC | DOTA_UNIT_TARGET_HERO"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_rem_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"IsPurgable"		"1"
+				"IsStunDebuff"		"0"
+
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"OnCreated"
+				{
+					"ApplyMotionController"
+					{
+					    "Target" 		"TARGET"
+					    "ScriptFile"    "heroes/rem/ability_rem_4.lua"
+					    "HorizontalControlFunction" "bvo_rem_skill_4_knockback"
+					}
+				}	
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rem/ability_rem_4.lua"
+				"Function"		"bvo_rem_skill_4"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  	"particles/generic_gameplay/generic_stunned_old.vpcf"
+			"particle"  	"particles/units/heroes/hero_tidehunter/tidehunter_gush_upgrade.vpcf"
+			"soundfile" 	"soundevents/game_sounds_heroes/game_sounds_morphling.vsndevts"
+		}
+	}
+
+	"bvo_rem_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_rem_skill_5"
+		"AOERadius"								"%radius"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"700"
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_3"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"475"
+		"AbilityCooldown"						"100"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"1000"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"5.5 7.0 8.25 9.25 10.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"radius"						"275"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"interval"						"0.25"
+			}
+			"05"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"delay"							"0.25"
+			}
+			"06"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"spread"						"6"
+			}
+			"07"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"waves"							"3 3 4 4 5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/rem/ability_rem_5.lua"
+				"Function"		"bvo_rem_skill_5"
+				"Target"		"POINT"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/kunkka/divine_anchor/hero_kunkka_dafx_skills/kunkka_spell_torrent_splash_fxset.vpcf"
+			"particle"  "particles/econ/items/kunkka/divine_anchor/hero_kunkka_dafx_skills/kunkka_spell_torrent_bubbles_fxset.vpcf"
+		}
+	}
+
+	//Kissshot
+	"bvo_kissshot_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_0"
+		
+		"MaxLevel"								"1"
+
+		"AbilityCooldown"						"70"
+		"AbilityManaCost"						"75"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"reincarnate_time"		"5.0"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kissshot_skill_0_reincarnation_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"OnTakeDamage"
+				{
+					"RunScript"
+					{
+						"ScriptFile"		"heroes/kissshot/ability_kissshot_0.lua"
+						"Function"			"bvo_kissshot_skill_0"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"	"soundevents/game_sounds_heroes/game_sounds_skeletonking.vsndevts"
+		}
+	}
+
+	"bvo_kissshot_skill_1"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_1"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.2"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"100 120 140 160 180"
+		"AbilityCooldown"						"11.0"
+		"AbilityCastRange"						"1150"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"225 250 300 375 475 600"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"agi_multi"						"0.4 0.55 0.7 0.85 1.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.KissshotSkill1"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/custom/kissshot/kissshot_skill_1/kissshot_skill_1_orig.vpcf"
+				"MoveSpeed" "5000"
+				"StartRadius" "150"
+				"EndRadius" "200"
+				"FixedDistance" "1150"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/kissshot/ability_kissshot_1.lua"
+				"Function"		"bvo_kissshot_skill_1"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/custom/kissshot/kissshot_skill_1/kissshot_skill_1_orig.vpcf"
+		}
+	}
+
+	"bvo_kissshot_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_2"
+		"AOERadius"								"%radius"
+
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"lifesteal"				"2"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"radius"				"900"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"armor"					"-4 -8 -12 -14 -18"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kissshot_skill_2_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"0"
+				"IsBuff"	"1"
+
+				"OnAttackLanded"
+				{
+					"Lifesteal"
+					{
+						"Target"            "CASTER"
+						"LifestealPercent"	"%lifesteal"
+					}
+				}
+
+				"Aura"          	"bvo_kissshot_skill_2_effect_modifier"
+				"Aura_Radius"   	"%radius"
+				"Aura_Teams"    	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"Aura_Types"    	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"Aura_Flags"    	"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				"Aura_ApplyToCaster" "0"
+			}
+
+			"bvo_kissshot_skill_2_effect_modifier"
+			{
+				"Passive"	"0"
+				"IsHidden"	"0"
+				"IsDebuff"	"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%armor"
+				}
+			}
+		}
+
+		"precache"
+		{
+		}
+	}
+
+	"bvo_kissshot_skill_3"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_3"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+
+		"AOERadius"								"%aoe"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.6"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AnimationPlaybackRate"					"2"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"350"
+		"AbilityCooldown"						"30 35 40 45 50"
+		"AbilityCastRange"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"150 200 250 300 350"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"lvl_multi"						"25 30 35 40 45"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"aoe"							"375"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_bloodseeker/bloodseeker_bloodritual_explode.vpcf"
+				"EffectAttachType"	"start_at_customorigin"
+				"TargetPoint"		"POINT"
+
+				"ControlPoints"
+	            {
+	            	"01"	"%aoe %aoe %aoe"
+	            }
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_PhantomAssassin.CoupDeGrace.Arcana"
+				"Target"
+	            {
+	                "Center" "CASTER"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/kissshot/ability_kissshot_3.lua"
+				"Function"		"bvo_kissshot_skill_3"
+				"Target"		"POINT"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bloodseeker/bloodseeker_bloodritual_explode.vpcf"
+			"soundevents" "soundevents/game_sounds_heroes/game_sounds_phantom_assassin.vsndevts"
+		}
+	}
+
+	"bvo_kissshot_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_4"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AOERadius"								"%aoe"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AnimationPlaybackRate"					"1"
+		"AnimationIgnoresModelScale"			"1"
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"375"
+		"AbilityCooldown"						"90 95 100 105 110"
+		"AbilityCastRange"						"1150"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"damage"						"800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"3.0 4.5 6.0 7.5 9.0"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"aoe"							"1000"
+			}
+			"04"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"stun_duration"					"2.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_kissshot_skill_4_cmd"
+				"Target" 		"CASTER"
+				"Duration"		"2.0"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"ability_ability"
+				"Function"		"playAnimation"
+				"animation"		"ACT_DOTA_CAST_ABILITY_4"
+			}
+			"FireEffect"
+			{
+				"EffectName"	"particles/econ/items/lina/lina_ti7/light_strike_array_pre_ti7.vpcf"
+				"EffectAttachType"	"start_at_customorigin"
+				"TargetPoint"		"POINT"
+				"ControlPoints"
+	            {
+	            	"00"	"POINT"
+	            	"01"	"%aoe %aoe %aoe"
+	            }
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.PreLightStrikeArray"
+				"Target"
+	            {
+	                "Center" "CASTER"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+			"DelayedAction"
+			{
+				"Delay"     "2.0"
+				"Action"    
+				{
+					"FireEffect"
+					{
+						"EffectName"	"particles/econ/items/lina/lina_ti7/lina_spell_light_strike_array_ti7.vpcf"
+						"EffectAttachType"	"start_at_customorigin"
+						"TargetPoint"		"POINT"
+
+						"ControlPoints"
+			            {
+			            	"00"	"POINT"
+			            	"01"	"%aoe %aoe %aoe"
+			            	"03"	"0 0 0"
+			            }
+					}
+					"FireSound"
+					{
+						"EffectName"	"Ability.LightStrikeArray"
+						"Target"
+			            {
+			                "Center" "CASTER"
+			                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+			            }
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/kissshot/ability_kissshot_4.lua"
+						"Function"		"bvo_kissshot_skill_4"
+						"Target"		"POINT"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_kissshot_skill_4_cmd"
+			{
+				"Passive"			"0"
+				"IsHidden"			"1"
+				"IsBuff"			"1"
+
+				"States"
+				{
+					"MODIFIER_STATE_COMMAND_RESTRICTED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_STUNNED" 				"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_NO_HEALTH_BAR"  		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "-100"
+				}
+			}
+
+			"bvo_kissshot_skill_4_stun"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/generic_gameplay/generic_stunned.vpcf"
+				"EffectAttachType"	"follow_overhead"
+		
+				"States"
+				{
+					"MODIFIER_STATE_STUNNED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/lina/lina_ti7/lina_spell_light_strike_array_ti7.vpcf"
+			"particle"  "particles/generic_gameplay/generic_stunned.vpcf"
+		}
+	}
+
+	"bvo_kissshot_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitTargetFlags" 				"DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_kissshot_skill_5"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PHYSICAL"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastRange"						"%cast_range"
+		"AbilityCastPoint"						"0.5"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE_RARE"
+		"AnimationPlaybackRate"					"0.1"
+		"AnimationIgnoresModelScale"			"1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"						"FIELD_INTEGER"
+				"cast_range"					"600 650 700 750 800"
+			}
+			"02"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"change_to_kill"				"50"
+			}
+			"03"
+			{
+				"var_type"						"FIELD_FLOAT"
+				"str_multi"						"5.0 6.5 8.0 9.5 11.0"
+			}
+		}
+
+		// Stats
+		//----------------------------------------------------------------------------------------
+		"AbilityManaCost"						"525"
+		"AbilityCooldown"						"180"
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/centaur/centaur_ti6/centaur_ti6_warstomp_shockwave.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/custom/kissshot/kissshot_skill_5/kissshot_stare_target.vpcf"
+				"EffectAttachType"  "attach_origin"
+				"Target"            "TARGET"
+			}
+			"FireSound"
+			{
+				"EffectName"	"BleachVsOnePieceReborn.KissshotSkill5"
+				"Target"
+	            {
+	                "Center" "TARGET"
+	                "Flags" "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+	            }
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/kissshot/ability_kissshot_5.lua"
+				"Function"		"bvo_kissshot_skill_5"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/custom/kissshot/kissshot_skill_5/kissshot_stare_target.vpcf"
+			"particle"  "particles/econ/items/centaur/centaur_ti6/centaur_ti6_warstomp_shockwave.vpcf"
+		}
+	}
+
+	// Akainu
+	"bvo_akainu_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_0"
+		
+		"MaxLevel"								"1"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"reflect"				"2.5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"percent_damage_block"	"-7.5"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_akainu_skill_0_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+
+				"IsPurgable"		"0"
+				"IsStunDebuff"		"0"
+
+				"OnAttacked"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/akainu/ability_akainu_0"
+						"Function"		"bvo_akainu_skill_0"
+						"attacker"		"ATTACKER"
+					}
+				}
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "%percent_damage_block"
+				}
+			}
+		}
+	}
+
+	"bvo_akainu_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_DIRECTIONAL | DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_1"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+		// Casting
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityCastRange"				"500"
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"			"2.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"1"
+		"AbilityManaCost"				"80 90 100 110 120"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"str_multi"				"1.0 1.5 2.0 2.5 3.0 3.5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"recharge_cd"			"10"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"max_stacks"			"3"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"damage"				"75 100 125 150 175"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/akainu/ability_akainu_1.lua"
+				"Function"		"bvo_akainu_skill_1"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_akainu_skill_1_load_modifier"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+				"Duration"		"%recharge_cd"
+			}
+			"LinearProjectile"
+			{
+				"Target" "POINT"
+				"EffectName" "particles/units/heroes/hero_lina/lina_spell_dragon_slave.vpcf"
+				"MoveSpeed" "2000"
+				"StartRadius" "100"
+				"EndRadius" "200"
+				"FixedDistance" "700"
+				"StartPosition" "CASTER"
+				"TargetTeams" "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes" "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags" "DOTA_UNIT_TARGET_FLAG_NONE"
+				"HasFrontalCone" "0"
+				"ProvidesVision" "1"
+				"VisionRadius" "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DragonKnight.BreathFire"
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES | DOTA_UNIT_TARGET_FLAG_INVULNERABLE"
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_akainu_skill_1_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+
+				"OnCreated"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/akainu/ability_akainu_1.lua"
+						"Function"		"bvo_akainu_skill_1_init"
+					}
+				}
+			}
+
+			"bvo_akainu_skill_1_load_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_PERMANENT | MODIFIER_ATTRIBUTE_MULTIPLE"
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/akainu/ability_akainu_1.lua"
+						"Function"		"bvo_akainu_skill_1_charge"
+					}
+				}
+			}
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit" "0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/akainu/ability_akainu_1.lua"
+				"Function"		"bvo_akainu_skill_1_hit"
+			}
+		}
+
+		"precache"
+		{
+			"particle" "particles/units/heroes/hero_lina/lina_spell_dragon_slave.vpcf"
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_dragon_knight.vsndevts"
+		}
+	}
+
+	"bvo_akainu_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_2"
+		
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"armor"					"5 10 15 20 25"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"magic_resist"			"0 5 10 15 20"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_akainu_skill_2_modifier"
+			{
+				"Passive"	"1"
+				"IsHidden"	"1"
+				"IsBuff"	"1"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%armor"
+					"MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS" "%magic_resist"
+				}
+			}
+		}
+	}
+
+	"bvo_akainu_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_POINT"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_3"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.4"
+		"AbilityCastRange"				"1000"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+
+		"AbilityCooldown"				"40.0"
+		"AbilityManaCost"				"275"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"8 9 10 11 12"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire_.vpcf"
+				"MoveSpeed"		 "2000"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "2000"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_ENEMY"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"						
+			    "ProvidesVision" "1"
+			    "VisionRadius" 	 "250"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_Lina.DragonSlave"
+				"Target" 		"CASTER"
+			}
+			
+		}
+
+		"OnProjectileHitUnit"
+		{
+			"DeleteOnHit"	"0"
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/akainu/ability_akainu_3.lua"
+				"Function"		"bvo_akainu_skill_3_hit"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire_.vpcf"
+			"soundfile" "soundevents\game_sounds_heroes\game_sounds_lina.vsndevts"
+		}
+	}
+
+	"bvo_akainu_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.6"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilityCastRange"				"250"
+
+		"AbilityCooldown"				"75"
+		"AbilityManaCost"				"350"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"str_multi"			"1 2 3 4 5"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"1000 1250 1500 1750 2000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Invoker.SunStrike.Ignite"
+				"Target" 		"CASTER"
+			}
+			"LinearProjectile"
+			{
+			    "Target"      	 "POINT"
+				"EffectName"	 "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+				"MoveSpeed"		 "5"
+				"StartRadius"	 "250"
+				"StartPosition"  "attach_attack1"
+				"EndRadius"      "250"
+				"HasFrontalCone" "0"
+				"FixedDistance"  "5"
+				"TargetTeams"	 "DOTA_UNIT_TARGET_TEAM_NONE"
+				"TargetTypes"	 "DOTA_UNIT_TARGET_NONE"
+				"TargetFlags"	 "DOTA_UNIT_TARGET_FLAG_NONE"
+			    "ProvidesVision" "0"
+			    "VisionRadius" 	 "250"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/shadow_fiend/sf_fire_arcana/sf_fire_arcana_shadowraze.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/akainu/ability_akainu_4.lua"
+				"Function"		"bvo_akainu_skill_4"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/econ/items/shadow_fiend/sf_fire_arcana/sf_fire_arcana_shadowraze.vpcf"
+			"particle"  "particles/units/heroes/hero_dragon_knight/dragon_knight_breathe_fire.vpcf"
+		}
+	}
+
+	"bvo_akainu_skill_5"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_MAGICAL"
+		"AbilityTextureName"					"icons/bvo_akainu_skill_5"
+
+		"AOERadius"								"%radius"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.6"
+		"AbilityCastAnimation"			"ACT_DOTA_ATTACK"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilityCastRange"				"250"
+
+		"AbilityCooldown"				"100"
+		"AbilityManaCost"				"425"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"str_multi"			"10 12.5 15 17.5 20"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"275"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_warlock/warlock_rain_of_chaos.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Ability.LightStrikeArray"
+				"Target" 		"CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"TARGET"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/akainu/ability_akainu_5.lua"
+						"Function"		"bvo_akainu_skill_5"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_warlock/warlock_rain_of_chaos.vpcf"
+		}
+	}
+
+	// Perona
+	"bvo_perona_skill_0"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING"
+		"AbilityTextureName"					"icons/bvo_perona_skill_0"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"				"0.1"
+		"AbilityCastAnimation"			"ACT_DOTA_IDLE"
+		"AbilityCooldown"				"8.0"
+		"AbilityManaCost"				"50"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"4.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_dark_willow/dark_willow_leyconduit_marker.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+				"ControlPoints"
+				{
+					"02"		"100 100 100"
+				}
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_perona_skill_0_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DarkWillow.Shadow_Realm"
+				"Target" 		"CASTER"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_perona_skill_0_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+			
+				"EffectName"		"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+				"EffectAttachType"	"follow_hitloc"
+
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "650"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  		"particles/units/heroes/hero_dark_willow/dark_willow_leyconduit_marker.vpcf"
+			"particle"			"particles/units/heroes/hero_dark_seer/dark_seer_surge.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_dark_willow.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_1"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_perona_skill_1"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+		"RequiredLevel"							"1"
+		"LevelsBetweenUpgrades"					"3"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"						"15.0 17.5 20.0 22.5 25.0 27.5"
+		"AbilityManaCost"						"200 250 300 350 400 450"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"30"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"count"				"1 1 1 1 1 2"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"extra_health"		"0 400 800 1200 1600 2000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Visage.SummonFamiliars.Cast"
+				"Target" 		"CASTER"
+			}
+			"SpawnUnit"
+			{
+				"UnitName"		"npc_dota_perona_ghost_explode"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+				"UnitCount"		"%count"
+				"UnitLimit"		"0"
+				"GrantsGold"	"0"
+				"GrantsXP"		"0"
+				"SpawnRadius"	"10"
+				"OnSpawn"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_phased"
+						"Target"		"TARGET"
+						"Duration"		"0.03"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/perona/ability_perona_1.lua"
+						"Function"		"bvo_perona_skill_1"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_visage.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_2"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_perona_skill_2"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"3"
+		"LevelsBetweenUpgrades"					"4"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"						"10 15 20 25 30"
+		"AbilityManaCost"						"300 350 400 450 500"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"30 40 50 60 70"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"count"				"1 1 2 2 3"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"extra_health"		"0 500 1000 1500 2000 2500"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Visage.SummonFamiliars.Cast"
+				"Target" 		"CASTER"
+			}
+			"SpawnUnit"
+			{
+				"UnitName"		"npc_dota_perona_ghost_normal"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+				"UnitCount"		"%count"
+				"UnitLimit"		"0"
+				"GrantsGold"	"0"
+				"GrantsXP"		"0"
+				"SpawnRadius"	"40"
+				"OnSpawn"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_phased"
+						"Target"		"TARGET"
+						"Duration"		"0.03"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/perona/ability_perona_2.lua"
+						"Function"		"bvo_perona_skill_2"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_visage.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_3"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_perona_skill_3"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"6"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"						"60 50 40 30 20"
+		"AbilityManaCost"						"0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"4"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_DarkWillow.Ley.Cast"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_perona_skill_3_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/perona/ability_perona_3.lua"
+				"Function"		"bvo_perona_skill_3"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_perona_skill_3_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsBuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_dark_willow/dark_willow_shadow_realm.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"StatusEffectName" 		"particles/status_fx/status_effect_dark_willow_shadow_realm.vpcf"
+				"StatusEffectPriority"  "10"
+
+				"Properties"
+				{
+					"MODIFIER_PROPERTY_INCOMING_DAMAGE_PERCENTAGE" "-100"
+				}
+
+				"States"
+				{
+					"MODIFIER_STATE_SILENCED"		"MODIFIER_STATE_VALUE_ENABLED"
+					"MODIFIER_STATE_DISARMED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/status_fx/status_effect_dark_willow_shadow_realm.vpcf"
+			"particle"  "particles/units/heroes/hero_dark_willow/dark_willow_shadow_realm.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_dark_willow.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_4"
+	{
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_UNIT_TARGET"
+		"AbilityUnitTargetTeam"					"DOTA_UNIT_TARGET_TEAM_ENEMY"
+		"AbilityUnitTargetType"					"DOTA_UNIT_TARGET_HERO"
+		"AbilityUnitDamageType"					"DAMAGE_TYPE_PURE"
+		"AbilityTextureName"					"icons/bvo_perona_skill_4"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"12"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"				"0.2"
+		"AbilityCastAnimation"			"ACT_DOTA_CAST_ABILITY_1"
+		"AnimationPlaybackRate"			"1.0"
+		"AnimationIgnoresModelScale"	"1"
+		"AbilityCastRange"				"900"
+
+		"AbilityCooldown"				"70"
+		"AbilityManaCost"				"400"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"int_multi"			"1.0 1.75 2.5 3.25 4.0"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"800 900 1000 1100 1200"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_FLOAT"
+				"duration"			"4.0"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_perona_skill_4_modifier"
+				"Target" 		"TARGET"
+				"Duration"		"%duration"
+			}
+			"FireSound"
+			{
+				"EffectName"	"Hero_DarkWillow.Fear.Cast"
+				"Target" 		"TARGET"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/econ/items/dark_willow/dark_willow_chakram_immortal/dark_willow_bramble_precast.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "TARGET"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/perona/ability_perona_4.lua"
+				"Function"		"bvo_perona_skill_4"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_perona_skill_4_modifier"
+			{
+				"Passive"			"0"
+				"IsHidden"			"0"
+				"IsDebuff"			"1"
+		
+				"EffectName"		"particles/units/heroes/hero_bane/bane_fiends_grip.vpcf"
+				"EffectAttachType"	"follow_origin"
+
+				"States"
+				{
+					"MODIFIER_STATE_ROOTED"		"MODIFIER_STATE_VALUE_ENABLED"
+				}
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_bane/bane_fiends_grip.vpcf"
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_dark_willow.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_5"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"AbilityTextureName"					"icons/bvo_perona_skill_5"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+		"RequiredLevel"							"20"
+		"LevelsBetweenUpgrades"					"5"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_CAST_ABILITY_2"
+		"AbilityCooldown"						"100 95 90 85 80"
+		"AbilityManaCost"						"600"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"60 65 70 75 80"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"count"				"1 1 1 1 1"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"extra_health"		"0 1000 2000 3000 4000"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Visage.SummonFamiliars.Cast"
+				"Target" 		"CASTER"
+			}
+			"SpawnUnit"
+			{
+				"UnitName"		"npc_dota_perona_ghost_big"
+				"Target" 		"CASTER"
+				"Duration"		"%duration"
+				"UnitCount"		"%count"
+				"UnitLimit"		"0"
+				"GrantsGold"	"0"
+				"GrantsXP"		"0"
+				"SpawnRadius"	"40"
+				"OnSpawn"
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"modifier_phased"
+						"Target"		"TARGET"
+						"Duration"		"0.03"
+					}
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/perona/ability_perona_5.lua"
+						"Function"		"bvo_perona_skill_5"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile" "soundevents/game_sounds_heroes/game_sounds_visage.vsndevts"
+		}
+	}
+
+	// Perona Ghosts
+	"bvo_perona_skill_ghost_phase"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_IGNORE_BACKSWING | DOTA_ABILITY_BEHAVIOR_IMMEDIATE"
+		"AbilityTextureName"					"icons/bvo_perona_skill_ghost_phase"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"1"
+
+		"AbilityCastPoint"						"0.0"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AbilityCooldown"						"60"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"duration"			"5"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_TemplarAssassin.Meld"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"modifier_phased"
+				"Target"		"CASTER"
+				"Duration"		"%duration"
+			}
+			"RunScript"
+			{
+				"ScriptFile"	"heroes/perona/ability_perona_ghost_phase.lua"
+				"Function"		"bvo_perona_skill_ghost_phase"
+			}
+		}
+	}
+
+	"bvo_perona_skill_1_ghost"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_NO_TARGET | DOTA_ABILITY_BEHAVIOR_AOE"
+		"AbilityTextureName"					"icons/bvo_perona_skill_1_ghost"
+		
+		"AOERadius"								"%radius"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"6"
+
+		"AbilityCastPoint"						"0.1"
+		"AbilityCastAnimation"					"ACT_DOTA_IDLE"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"radius"			"275"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"200 500 800 1100 1400 1700"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Techies.Suicide"
+				"Target" 		"CASTER"
+			}
+			"FireEffect"
+			{
+				"EffectName"        "particles/units/heroes/hero_techies/techies_suicide_base.vpcf"
+				"EffectAttachType"  "follow_origin"
+				"Target"            "CASTER"
+			}
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+				}
+			
+				"Action"    
+				{
+					"Damage"
+					{
+						"Target"		"TARGET"
+						"Type"			"DAMAGE_TYPE_PURE"
+						"Damage"		"%damage"
+					}
+				}
+			}
+			"Damage"
+			{
+				"Target"		"CASTER"
+				"Type"			"DAMAGE_TYPE_PURE"
+				"Damage"		"100"
+				"CurrentHealthPercentBasedDamage"	"1"
+			}
+		}
+
+		"precache"
+		{
+			"particle"  "particles/units/heroes/hero_techies/techies_suicide_base.vpcf"
+			"soundfile"		"soundevents/game_sounds_heroes/game_sounds_techies.vsndevts"
+		}
+	}
+
+	"bvo_perona_skill_2_ghost"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+		
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"ms"				"0 50 100 150 200"
+			}
+			"02"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"as"				"0 10 20 30 40"
+			}
+			"03"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"damage"			"0 20 35 50 65 80"
+			}
+			"04"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"armor"				"0 3 6 9 14"
+			}
+			"05"
+			{
+				"var_type"			"FIELD_INTEGER"
+				"magic_resist"		"0 5 10 15 20"
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_perona_skill_2_ghost_modifier"
+			{
+				"Passive"			"1"
+				"IsHidden"			"1"
+		
+				"Properties"
+				{
+				    "MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "%ms"
+				    "MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "%as"
+				    "MODIFIER_PROPERTY_BASEATTACK_BONUSDAMAGE"	"%damage"
+				    "MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS"	"%armor"
+				    "MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS"	"%magic_resist"
+				}
+			}
+		}
+	}
+
+	"bvo_perona_skill_5_ghost"
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"								"ability_datadriven"
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_IMMEDIATE | DOTA_ABILITY_BEHAVIOR_NO_TARGET"
+		"SpellImmunityType"						"SPELL_IMMUNITY_ENEMIES_YES"
+		"AbilityTextureName"					"icons/bvo_perona_skill_5_ghost"
+
+		"AOERadius"								"%radius"
+		"AbilityType"							"DOTA_ABILITY_TYPE_BASIC"
+		"MaxLevel"								"5"
+
+		"AbilityCooldown"						"25.0"
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration_call"			"2.0 2.25 2.5 2.75 3.0"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"radius"				"200 225 250 275 300"
+			}
+		}
+
+		"OnSpellStart"
+		{
+			"FireSound"
+			{
+				"EffectName"	"Hero_Axe.Berserkers_Call"
+				"Target" 		"CASTER"
+			}
+			"RemoveModifier"
+			{
+				"ModifierName"	"bvo_perona_skill_5_ghost_caster_modifier"
+				"Target" 		"CASTER"
+			}
+			"ApplyModifier"
+			{
+				"ModifierName"	"bvo_perona_skill_5_ghost_caster_modifier"
+				"Target" 		"CASTER"
+				"Duration"		"%duration_call"
+			}
+
+			"ActOnTargets"
+			{
+				"Target"
+				{
+					"Center"  	"CASTER"
+					"Radius" 	"%radius"
+					"Teams" 	"DOTA_UNIT_TARGET_TEAM_ENEMY"
+					"Types" 	"DOTA_UNIT_TARGET_HERO | DOTA_UNIT_TARGET_BASIC"
+					"Flags"     "DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES"
+				}
+			
+				"Action"    
+				{
+					"ApplyModifier"
+					{
+						"ModifierName"	"bvo_perona_skill_5_ghost_target_modifier"
+						"Target" 		"TARGET"
+						"Duration"		"%duration_call"
+					}
+				}
+			}
+		}
+
+		"Modifiers"
+		{
+			"bvo_perona_skill_5_ghost_caster_modifier"
+			{
+				"IsPurgable"		"0"
+				"IsBuff"			"1"
+				"Attributes"		"MODIFIER_ATTRIBUTE_NONE"
+
+				"OnCreated"
+				{
+					"AttachEffect"
+					{
+						"Target"			"CASTER"
+						"EffectName"        "particles/units/heroes/hero_axe/axe_beserkers_call_owner.vpcf"
+						"EffectAttachType" 	"follow_origin"
+						"ControlPoints"
+						{
+							"02"		"%radius 1 1"
+						}
+						"ControlPointEntities"
+						{
+							"CASTER"	"follow_origin"
+							"CASTER"	"follow_origin"
+							"CASTER"	"follow_origin"
+						}
+					}
+				}
+			}
+
+			"bvo_perona_skill_5_ghost_target_modifier"
+			{
+				"IsPurgable"		"0"
+				"IsDebuff"			"1"
+
+				"StatusEffectName" 		"particles/status_fx/status_effect_beserkers_call.vpcf" 	   
+				"StatusEffectPriority"  "10"
+
+				"ThinkInterval"  "0.1"
+				"OnIntervalThink"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/perona/ability_perona_ghost_call.lua"
+						"Function"		"item_bladebane_armor_BerserkersCall"
+					}
+				}
+
+				"OnDestroy"
+				{
+					"RunScript"
+					{
+						"ScriptFile"	"heroes/perona/ability_perona_ghost_call.lua"
+						"Function"		"item_bladebane_armor_BerserkersCallEnd"
+					}
+				}
+			}
+		}
+
+		"precache"
+		{
+			"soundfile"			"soundevents/game_sounds_heroes/game_sounds_axe.vsndevts"
+			"particle"			"particles/units/heroes/hero_axe/axe_beserkers_call_owner.vpcf"
+			"particle"			"particles/status_fx/status_effect_beserkers_call.vpcf"
+		}
+	}
+
+	//talents
+	//generic
+	"bvo_special_bonus_magic_resist_25"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_armor_15"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_health_650"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_damage_75"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_evasion_15"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_attack_speed_80"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_lifesteal_10"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+
+	"bvo_special_bonus_reduced_damage_10"
+	{
+		"BaseClass"								"special_bonus_undefined"
+
+		"AbilityBehavior"						"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+
+		"AbilityType"							"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"MaxLevel"								"1"
+	}
+}


### PR DESCRIPTION
Community Update:
- Reduced Lifesteal talents from 10% to 3%
- Reduced Magic Resistance Talent from 25% to 10%

Byakuya:
- Fixed Byakuya Petal ability attack intervals. (Nerfed)
- Increased Byakuya Skill 2 Cooldown from 22 to 30
- Reduced Byakuya Skill 2 Cast Range from 600 to 250
- Reduced AGI Gain from 3.75 to 35
- Reduced Base AGI from 40 to 35
- Reduced STR Gain from 2.75 to 2.5

Akainu:
- Reduced STR gain from 4.5 to 3.5
- Reduced AGI gain from 3.5 to 2.5
- Base Max HP reduced from 410 to 400
- Reduced Akainu's Skill 1 Cast Range from 700 to 500
- Reduced Akainu's Skill 1 Cooldown from 0.5 to 1

Moria:
- Fixed Moria's bat swarm ability attack intervals. (Nerfed)